### PR TITLE
GameObjectクラスのtemplateを使った関数がエラー出すバグを修正

### DIFF
--- a/Engine/Core/src/yougine/GameObject.cpp
+++ b/Engine/Core/src/yougine/GameObject.cpp
@@ -45,54 +45,7 @@ namespace yougine
         return gameobject_childs;
     }
 
-    template <class T> T* GameObject::GetComponent()
-    {
-        T* component;
 
-        for (components::Component* c : component_list)
-        {
-            component = dynamic_cast<T*>(c);
-            if (component != nullptr)
-            {
-                return component;
-            }
-        }
-
-        return nullptr;
-    }
-
-    //component already exist on component_list, not add & return nullptr
-    template <class T> T* GameObject::AddComponent()
-    {
-        for (components::Component* c : component_list)
-        {
-            if (typeid(c) == typeid(T*))
-            {
-                return nullptr;
-            }
-        }
-
-        T* component = new T();
-        component_list.push_back(component);
-        return component;
-    }
-
-    template <class T> void GameObject::RemoveComponent()
-    {
-        T* component;
-        std::vector<components::Component*> new_list;
-
-        for (components::Component* c : GetComponents())
-        {
-            component = dynamic_cast<T*>(c);
-            if (component == nullptr)
-            {
-                new_list.push_back(c);
-            }
-        }
-
-        component_list = new_list;
-    }
 
     bool GameObject::operator==(const GameObject& rhs) const
     {

--- a/Engine/Core/src/yougine/GameObject.h
+++ b/Engine/Core/src/yougine/GameObject.h
@@ -29,9 +29,55 @@ namespace yougine
         void AddChild(GameObject*);
         GameObject* GetParentObject();
         std::vector<GameObject*> GetChildObjects();
-        template <class T> T* GetComponent();
-        template <class T> T* AddComponent();
-        template <class T> void RemoveComponent();
         bool operator==(const GameObject& rhs) const;
+
+        template <class T> T* GetComponent()
+        {
+            T* component;
+
+            for (components::Component* c : component_list)
+            {
+                component = dynamic_cast<T*>(c);
+                if (component != nullptr)
+                {
+                    return component;
+                }
+            }
+
+            return nullptr;
+        }
+
+        //component already exist on component_list, not add & return nullptr
+        template <class T> T* AddComponent()
+        {
+            for (components::Component* c : component_list)
+            {
+                if (typeid(c) == typeid(T*))
+                {
+                    return nullptr;
+                }
+            }
+
+            T* component = new T();
+            component_list.push_back(component);
+            return component;
+        }
+
+        template <class T> void RemoveComponent()
+        {
+            T* component;
+            std::vector<components::Component*> new_list;
+
+            for (components::Component* c : GetComponents())
+            {
+                component = dynamic_cast<T*>(c);
+                if (component == nullptr)
+                {
+                    new_list.push_back(c);
+                }
+            }
+
+            component_list = new_list;
+        }
     };
 }

--- a/Engine/Core/src/yougine/components/Component.h
+++ b/Engine/Core/src/yougine/components/Component.h
@@ -17,7 +17,7 @@ namespace yougine::components
     public:
         Component();
         ~Component();
-        void Excute();
+        virtual void Excute();
         void InitializeOnPlayBack();
         bool operator==(const Component& rhs) const;
         GameObject* GetGameObject();


### PR DESCRIPTION
GameObjectクラスのtemplateを使った関数の実装をヘッダーに移動（cpp側だとリンクエラーになる）