### PR TITLE
GameObjectにAddComponentメソッドを実装した

### DIFF
--- a/Engine/Core/src/yougine/Editor/SceneWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/SceneWindow.cpp
@@ -3,10 +3,10 @@
 #include <iostream>
 
 editor::SceneWindow::SceneWindow(editor::EditorWindowsManager* editor_windows_manager,
-    yougine::Scene*) : EditorWindow(editor_windows_manager,
+    yougine::Scene* scene) : EditorWindow(editor_windows_manager,
         editor::EditorWindowName::SceneWindow)
 {
-    this->renderManager = new yougine::managers::RenderManager(100, 100);
+    this->renderManager = new yougine::managers::RenderManager(100, 100, scene->GetComponentList());
 }
 
 void editor::SceneWindow::Draw()

--- a/Engine/Core/src/yougine/Editor/SceneWindow.h
+++ b/Engine/Core/src/yougine/Editor/SceneWindow.h
@@ -6,7 +6,7 @@ namespace editor
     class SceneWindow : public editor::EditorWindow
     {
     public:
-        SceneWindow(editor::EditorWindowsManager* editor_windows_manager, yougine::Scene*);
+        SceneWindow(editor::EditorWindowsManager* editor_windows_manager, yougine::Scene* scene);
         void Draw() override;
     private:
         yougine::managers::RenderManager* renderManager;

--- a/Engine/Core/src/yougine/GameObject.cpp
+++ b/Engine/Core/src/yougine/GameObject.cpp
@@ -1,5 +1,6 @@
 #include "GameObject.h"
 
+#include "components/Component.h"
 
 namespace yougine
 {
@@ -46,10 +47,14 @@ namespace yougine
         return gameobject_childs;
     }
 
-
-
     bool GameObject::operator==(const GameObject& rhs) const
     {
         return *this == rhs;
+    }
+    void yougine::GameObject::AddComponent(components::Component* component)
+    {
+        // component
+        component->SetParentGameObject(this);
+        component->SetThisComponentToComponentList(this->scene);
     }
 }

--- a/Engine/Core/src/yougine/GameObject.cpp
+++ b/Engine/Core/src/yougine/GameObject.cpp
@@ -55,6 +55,6 @@ namespace yougine
     {
         // component
         component->SetParentGameObject(this);
-        component->SetThisComponentToComponentList(this->scene);
+        component->RegisterThisComponentToComponentList(this->scene);
     }
 }

--- a/Engine/Core/src/yougine/GameObject.h
+++ b/Engine/Core/src/yougine/GameObject.h
@@ -34,6 +34,8 @@ namespace yougine
         std::list<GameObject*> GetChildObjects();
         bool operator==(const GameObject& rhs) const;
 
+        void AddComponent(components::Component* component);
+
         template <class T> T* GetComponent()
         {
             T* component;
@@ -48,22 +50,6 @@ namespace yougine
             }
 
             return nullptr;
-        }
-
-        //component already exist on component_list, not add & return nullptr
-        template <class T> T* AddComponent()
-        {
-            for (components::Component* c : components)
-            {
-                if (typeid(c) == typeid(T*))
-                {
-                    return nullptr;
-                }
-            }
-
-            T* component = new T();
-            components.push_back(component);
-            return component;
         }
 
         template <class T> void RemoveComponent()

--- a/Engine/Core/src/yougine/components/Component.cpp
+++ b/Engine/Core/src/yougine/components/Component.cpp
@@ -53,12 +53,13 @@ namespace yougine::components
     {
         if (this->parent_gameobject == nullptr)
         {
-            //parent_gameobjectが
+            //parent_gameobjectがnullならエラー
             throw "exception,this compoent does not have parentGameobject";
             return;
         }
         else if (this->component_name == managers::ComponentName::kNone)
         {
+            //componentnameがkNoneなのにComponentListに追加しようとしているのでエラー
             throw "throw,this component can not register to ComponentList";
             return;
         }

--- a/Engine/Core/src/yougine/components/Component.cpp
+++ b/Engine/Core/src/yougine/components/Component.cpp
@@ -3,9 +3,10 @@
 
 namespace yougine::components
 {
-    Component::Component()
+    Component::Component(managers::ComponentName componentname)
     {
         this->parent_gameobject = nullptr;
+        this->component_name = componentname;
     }
 
     Component::~Component()
@@ -52,9 +53,15 @@ namespace yougine::components
     {
         if (this->parent_gameobject == nullptr)
         {
+            //parent_gameobject‚ª
             throw "exception,this compoent does not have parentGameobject";
             return;
         }
-        scene->GetComponentList()->AddObjectToDictionary(managers::ComponentName::kCustom, this->parent_gameobject);
+        else if (this->component_name == managers::ComponentName::kNone)
+        {
+            throw "throw,this component can not register to ComponentList";
+            return;
+        }
+        scene->GetComponentList()->AddObjectToDictionary(this->component_name, this->parent_gameobject);
     }
 }

--- a/Engine/Core/src/yougine/components/Component.cpp
+++ b/Engine/Core/src/yougine/components/Component.cpp
@@ -11,13 +11,11 @@ namespace yougine::components
 
     Component::~Component()
     {
-
     }
 
     //private
     void Component::InitializeProperties()
     {
-
     }
 
     //public
@@ -40,6 +38,7 @@ namespace yougine::components
     {
         return parent_gameobject;
     }
+
     void Component::SetParentGameObject(GameObject* parent_gameobject)
     {
         this->parent_gameobject = parent_gameobject;
@@ -49,8 +48,13 @@ namespace yougine::components
      * \brief parentgameobjectがnullの場合エラーを出す（SetParentGameObject関数を先に呼ばないとエラーになる）
      * \param scene parentGameobjectが所属するシーン
      */
-    void Component::SetThisComponentToComponentList(Scene* scene)
+    void Component::RegisterThisComponentToComponentList(Scene* scene)
     {
+        if (register_component_list != nullptr)
+        {
+            throw"this component is already registerd";
+            return;
+        }
         if (this->parent_gameobject == nullptr)
         {
             //parent_gameobjectがnullならエラー
@@ -64,5 +68,12 @@ namespace yougine::components
             return;
         }
         scene->GetComponentList()->AddObjectToDictionary(this->component_name, this->parent_gameobject);
+        this->register_component_list = scene->GetComponentList();
+    }
+
+    void Component::UnregisterThisComponentFromComponentList()
+    {
+        this->register_component_list->RemoveObjectFromDictionary(this->component_name, this);
+        this->register_component_list = nullptr;
     }
 }

--- a/Engine/Core/src/yougine/components/Component.cpp
+++ b/Engine/Core/src/yougine/components/Component.cpp
@@ -39,4 +39,22 @@ namespace yougine::components
     {
         return parent_gameobject;
     }
+    void Component::SetParentGameObject(GameObject* parent_gameobject)
+    {
+        this->parent_gameobject = parent_gameobject;
+    }
+
+    /**
+     * \brief parentgameobjectがnullの場合エラーを出す（SetParentGameObject関数を先に呼ばないとエラーになる）
+     * \param scene parentGameobjectが所属するシーン
+     */
+    void Component::SetThisComponentToComponentList(Scene* scene)
+    {
+        if (this->parent_gameobject == nullptr)
+        {
+            throw "exception,this compoent does not have parentGameobject";
+            return;
+        }
+        scene->GetComponentList()->AddObjectToDictionary(managers::ComponentName::kCustom, this->parent_gameobject);
+    }
 }

--- a/Engine/Core/src/yougine/components/Component.h
+++ b/Engine/Core/src/yougine/components/Component.h
@@ -6,6 +6,7 @@ namespace yougine
 {
     class GameObject;
 }
+
 namespace yougine::components
 {
     class Component
@@ -13,6 +14,11 @@ namespace yougine::components
     private:
         GameObject* parent_gameobject;
         managers::ComponentName component_name;
+        // bool isRegisterdToComponentList;
+        /**
+         * \brief “o˜^‚µ‚Ä‚¢‚éComponentList
+         */
+        managers::ComponentList* register_component_list;
 
     private:
         void InitializeProperties();
@@ -25,6 +31,7 @@ namespace yougine::components
         bool operator==(const Component& rhs) const;
         GameObject* GetGameObject();
         void SetParentGameObject(GameObject* parent_gameobject);
-        void SetThisComponentToComponentList(Scene* scene);
+        void RegisterThisComponentToComponentList(Scene* scene);
+        void UnregisterThisComponentFromComponentList();
     };
 }

--- a/Engine/Core/src/yougine/components/Component.h
+++ b/Engine/Core/src/yougine/components/Component.h
@@ -12,12 +12,13 @@ namespace yougine::components
     {
     private:
         GameObject* parent_gameobject;
+        managers::ComponentName component_name;
 
     private:
         void InitializeProperties();
 
     public:
-        Component();
+        Component(managers::ComponentName componentname);
         ~Component();
         virtual void Excute();
         void InitializeOnPlayBack();

--- a/Engine/Core/src/yougine/components/Component.h
+++ b/Engine/Core/src/yougine/components/Component.h
@@ -23,5 +23,7 @@ namespace yougine::components
         void InitializeOnPlayBack();
         bool operator==(const Component& rhs) const;
         GameObject* GetGameObject();
+        void SetParentGameObject(GameObject* parent_gameobject);
+        void SetThisComponentToComponentList(Scene* scene);
     };
 }

--- a/Engine/Core/src/yougine/components/RenderComponent.cpp
+++ b/Engine/Core/src/yougine/components/RenderComponent.cpp
@@ -1,1 +1,4 @@
 #include "RenderComponent.h"
+yougine::comoponents::RenderComponent::RenderComponent() :Component(managers::ComponentName::kRender)
+{
+}

--- a/Engine/Core/src/yougine/components/RenderComponent.h
+++ b/Engine/Core/src/yougine/components/RenderComponent.h
@@ -5,6 +5,7 @@ namespace yougine::comoponents
     class RenderComponent : public components::Component
     {
         //マテリアル（シェーダー、シェーダに渡す値）、メッシュ。
+    public:
         RenderComponent();
     };
 

--- a/Engine/Core/src/yougine/components/RenderComponent.h
+++ b/Engine/Core/src/yougine/components/RenderComponent.h
@@ -5,7 +5,7 @@ namespace yougine::comoponents
     class RenderComponent : public components::Component
     {
         //マテリアル（シェーダー、シェーダに渡す値）、メッシュ。
-
+        RenderComponent();
     };
 
 }

--- a/Engine/Core/src/yougine/components/TransformComponent.cpp
+++ b/Engine/Core/src/yougine/components/TransformComponent.cpp
@@ -2,7 +2,7 @@
 
 namespace yougine::components
 {
-    TransformComponent::TransformComponent(float x, float y, float z)
+    TransformComponent::TransformComponent(float x, float y, float z) : Component(managers::ComponentName::kNone)
     {
         this->position = new Vector3(x, y, z);
     }

--- a/Engine/Core/src/yougine/main.cpp
+++ b/Engine/Core/src/yougine/main.cpp
@@ -68,6 +68,13 @@ int main()
 
     yougine::Scene* scene = new yougine::Scene("Scene1");
 
+    //レンダーコンポーネントをAdd出来るかのコード（後で消す）
+    auto rendercomponent = new yougine::comoponents::RenderComponent();
+    auto rendercomponent2 = new yougine::comoponents::RenderComponent();
+    auto gameobject = new yougine::GameObject(scene, "hello", nullptr);
+    gameobject->AddComponent(rendercomponent);
+    gameobject->AddComponent(rendercomponent2);
+
     //Add Code
     yougine::InputManager* input_manager = new yougine::InputManager();
     editor::EditorWindowsManager* editor_windows_manager = new editor::EditorWindowsManager();

--- a/Engine/Core/src/yougine/managers/ComponentList.cpp
+++ b/Engine/Core/src/yougine/managers/ComponentList.cpp
@@ -30,4 +30,9 @@ namespace yougine::managers
     {
         return gameobjects_dictionary[component_name];
     }
+    //TODO À‘•‚·‚éIw’è‚µ‚½component‚ğíœ‚·‚é
+    void yougine::managers::ComponentList::RemoveObjectFromDictionary(managers::ComponentName component_name, components::Component* component)
+    {
+        //–¢À‘•
+    }
 }

--- a/Engine/Core/src/yougine/managers/ComponentList.h
+++ b/Engine/Core/src/yougine/managers/ComponentList.h
@@ -15,5 +15,6 @@ namespace yougine::managers
         std::map<ComponentName, std::vector<GameObject*>> GetObjectsDictionary();
         void AddObjectToDictionary(ComponentName, GameObject*);
         std::vector<GameObject*> GetReferObjectList(ComponentName);
+        void RemoveObjectFromDictionary(managers::ComponentName component_name, components::Component* component);
     };
 }

--- a/Engine/Core/src/yougine/managers/ComponentName.h
+++ b/Engine/Core/src/yougine/managers/ComponentName.h
@@ -8,6 +8,7 @@ namespace yougine::managers
         kRender,
         kUIRender,
         kUICollider,
-        kCustom
+        kCustom,
+        kNone//ComponentList‚ÉŠ‘®‚µ‚È‚¢‚â‚Â
     };
 }

--- a/Engine/Core/src/yougine/managers/RenderManager.cpp
+++ b/Engine/Core/src/yougine/managers/RenderManager.cpp
@@ -21,8 +21,10 @@ namespace yougine::managers
         GLfloat position[4];
     };
 
-    RenderManager::RenderManager(int width, int height)
+    RenderManager::RenderManager(int width, int height, managers::ComponentList* component_list)
     {
+        this->component_list = component_list;
+
         GLenum err;
         this->width = width;
         this->height = height;
@@ -72,6 +74,9 @@ namespace yougine::managers
         {
             std::cout << err << " というエラーがある" << std::endl;
         }
+        //componentを取得できるかのテスト用コード
+        auto render_component_List = component_list->GetReferObjectList(ComponentName::kRender);
+        std::cout << "renderComponent の数 : " << render_component_List.size() << std::endl;
     }
 
     /**

--- a/Engine/Core/src/yougine/managers/RenderManager.h
+++ b/Engine/Core/src/yougine/managers/RenderManager.h
@@ -11,7 +11,7 @@ namespace yougine::managers
     class RenderManager
     {
     public:
-        RenderManager(int width, int height);
+        RenderManager(int width, int height, ComponentList* component_list);
 
         void Initialize();
 
@@ -23,6 +23,7 @@ namespace yougine::managers
         void SetWindowSize(ImVec2 vec2);
 
     private:
+        ComponentList* component_list;
         int width, height;
         GLuint program;
         GLuint vao;


### PR DESCRIPTION
GameObjectにAddComponentメソッドは、ゲームオブジェクトにコンポーネントを追加し、さらに、ComponentListにその追加するコンポーネントを登録する。
＊RemoveObjectFromDictionaryは未実装です（issueに記載済み）