### PR TITLE
ComponentListの対象をGameObjectからComponentに変更し、GameObjectのRemoveComponentを使えるようにした

### DIFF
--- a/Engine/Core/src/yougine/GameObject.cpp
+++ b/Engine/Core/src/yougine/GameObject.cpp
@@ -65,4 +65,23 @@ namespace yougine
             this->components.push_back(component);
         }
     }
+
+    void GameObject::RemoveComponent(components::Component* component)
+    {
+        std::cout << "call RemoveComponent" << std::endl;
+        std::vector<components::Component*> new_components;
+        for (components::Component* c : GetComponents())
+        {
+            if (c != component)
+            {
+                new_components.push_back(c);
+            }else
+            {
+                component->UnregisterThisComponentFromComponentList();
+                std::cout << "componentをリムーブ！　" << std::endl;
+            }
+        }
+        this->components = new_components;
+    }
+
 }

--- a/Engine/Core/src/yougine/GameObject.h
+++ b/Engine/Core/src/yougine/GameObject.h
@@ -35,7 +35,7 @@ namespace yougine
         bool operator==(const GameObject& rhs) const;
 
         void AddComponent(components::Component* component);
-
+        void RemoveComponent(components::Component* component);
         template <class T> T* GetComponent()
         {
             T* component;
@@ -50,23 +50,6 @@ namespace yougine
             }
 
             return nullptr;
-        }
-
-        template <class T> void RemoveComponent()
-        {
-            T* component;
-            std::vector<components::Component*> new_list;
-
-            for (components::Component* c : GetComponents())
-            {
-                component = dynamic_cast<T*>(c);
-                if (component == nullptr)
-                {
-                    new_list.push_back(c);
-                }
-            }
-
-            components = new_list;
         }
     };
 }

--- a/Engine/Core/src/yougine/components/Component.cpp
+++ b/Engine/Core/src/yougine/components/Component.cpp
@@ -67,14 +67,14 @@ namespace yougine::components
             throw "throw,this component can not register to ComponentList";
             return false;
         }
-        scene->GetComponentList()->AddObjectToDictionary(this->component_name, this->parent_gameobject);
+        scene->GetComponentList()->AddObjectToDictionary(this->component_name, this);
         this->register_component_list = scene->GetComponentList();
         return true;
     }
 
     void Component::UnregisterThisComponentFromComponentList()
     {
-        this->register_component_list->RemoveObjectFromDictionary(this->component_name, this);
+        this->register_component_list->RemoveComponentFromDictionary(this->component_name, this);
         this->register_component_list = nullptr;
     }
 }

--- a/Engine/Core/src/yougine/main.cpp
+++ b/Engine/Core/src/yougine/main.cpp
@@ -74,6 +74,8 @@ int main()
     auto gameobject = new yougine::GameObject(scene, "hello", nullptr);
     gameobject->AddComponent(rendercomponent);
     gameobject->AddComponent(rendercomponent2);
+    gameobject->RemoveComponent(rendercomponent2);
+    std::cout << "gameobject has componet num "<<gameobject->GetComponents().size() << std::endl;
 
     //Add Code
     yougine::InputManager* input_manager = new yougine::InputManager();

--- a/Engine/Core/src/yougine/managers/ComponentList.cpp
+++ b/Engine/Core/src/yougine/managers/ComponentList.cpp
@@ -36,10 +36,23 @@ namespace yougine::managers
         return components_dictionary[component_name];
     }
 
-    //TODO À‘•‚·‚éIw’è‚µ‚½component‚ğíœ‚·‚é
-    void yougine::managers::ComponentList::RemoveObjectFromDictionary(managers::ComponentName component_name,
+    /**
+     * \brief component‚Ì“o˜^‚ğÁ‚·
+     * \param component_name 
+     * \param component 
+     */
+    void yougine::managers::ComponentList::RemoveComponentFromDictionary(managers::ComponentName component_name,
                                                                       components::Component* component)
     {
-        //–¢À‘•
+        auto target_component_list = components_dictionary[component_name];
+        vector<components::Component*> new_component_list;
+        for (auto* c : target_component_list)
+        {
+            if (c != component)
+            {
+                new_component_list.push_back(c);
+            }
+        }
+        components_dictionary[component_name] = new_component_list;
     }
 }

--- a/Engine/Core/src/yougine/managers/ComponentList.cpp
+++ b/Engine/Core/src/yougine/managers/ComponentList.cpp
@@ -1,37 +1,44 @@
 #include <vector>
 #include "ComponentList.h"
 
+#include "../components/Component.h"
+
 namespace yougine::managers
 {
     using std::vector;
     using std::map;
 
-    map<managers::ComponentName, vector<GameObject*>> gameobjects_dictionary =
+    ComponentList::ComponentList()
     {
-        { managers::ComponentName::kCollider, vector<GameObject*>() },
-        { managers::ComponentName::kRigidBody, vector<GameObject*>() },
-        { managers::ComponentName::kRender, vector<GameObject*>() },
-        { managers::ComponentName::kUIRender , vector<GameObject*>() },
-        { managers::ComponentName::kUICollider, vector<GameObject*>() },
-        { managers::ComponentName::kCustom, vector<GameObject*>() },
-    };
-
-    map<managers::ComponentName, vector<GameObject*>> ComponentList::GetObjectsDictionary()
-    {
-        return gameobjects_dictionary;
+        components_dictionary =
+        {
+            {managers::ComponentName::kCollider, vector<components::Component*>()},
+            {managers::ComponentName::kRigidBody, vector<components::Component*>()},
+            {managers::ComponentName::kRender, vector<components::Component*>()},
+            {managers::ComponentName::kUIRender, vector<components::Component*>()},
+            {managers::ComponentName::kUICollider, vector<components::Component*>()},
+            {managers::ComponentName::kCustom, vector<components::Component*>()},
+        };
     }
 
-    void ComponentList::AddObjectToDictionary(managers::ComponentName component_name, GameObject* gameobject)
+    map<managers::ComponentName, vector<components::Component*>> ComponentList::GetObjectsDictionary()
     {
-        gameobjects_dictionary[component_name].push_back(gameobject);
+        return components_dictionary;
     }
 
-    vector<GameObject*> ComponentList::GetReferObjectList(managers::ComponentName component_name)
+    void ComponentList::AddObjectToDictionary(managers::ComponentName component_name, components::Component* component)
     {
-        return gameobjects_dictionary[component_name];
+        components_dictionary[component_name].push_back(component);
     }
+
+    vector<components::Component*> ComponentList::GetReferObjectList(managers::ComponentName component_name)
+    {
+        return components_dictionary[component_name];
+    }
+
     //TODO é¿ëïÇ∑ÇÈÅIéwíËÇµÇΩcomponentÇçÌèúÇ∑ÇÈ
-    void yougine::managers::ComponentList::RemoveObjectFromDictionary(managers::ComponentName component_name, components::Component* component)
+    void yougine::managers::ComponentList::RemoveObjectFromDictionary(managers::ComponentName component_name,
+                                                                      components::Component* component)
     {
         //ñ¢é¿ëï
     }

--- a/Engine/Core/src/yougine/managers/ComponentList.h
+++ b/Engine/Core/src/yougine/managers/ComponentList.h
@@ -16,6 +16,6 @@ namespace yougine::managers
         std::map<ComponentName, std::vector<components::Component*>> GetObjectsDictionary();
         void AddObjectToDictionary(ComponentName component_name, components::Component* component);
         std::vector<components::Component*> GetReferObjectList(ComponentName);
-        void RemoveObjectFromDictionary(managers::ComponentName component_name, components::Component* component);
+        void RemoveComponentFromDictionary(managers::ComponentName component_name, components::Component* component);
     };
 }

--- a/Engine/Core/src/yougine/managers/ComponentList.h
+++ b/Engine/Core/src/yougine/managers/ComponentList.h
@@ -9,12 +9,13 @@ namespace yougine::managers
     class ComponentList
     {
     private:
-        std::map<ComponentName, std::vector<GameObject*>> gameobjects_dictionary;
+        std::map<ComponentName, std::vector<components::Component*>> components_dictionary;
 
     public:
-        std::map<ComponentName, std::vector<GameObject*>> GetObjectsDictionary();
-        void AddObjectToDictionary(ComponentName, GameObject*);
-        std::vector<GameObject*> GetReferObjectList(ComponentName);
+        ComponentList();
+        std::map<ComponentName, std::vector<components::Component*>> GetObjectsDictionary();
+        void AddObjectToDictionary(ComponentName component_name, components::Component* component);
+        std::vector<components::Component*> GetReferObjectList(ComponentName);
         void RemoveObjectFromDictionary(managers::ComponentName component_name, components::Component* component);
     };
 }

--- a/Engine/Core/src/yougine/managers/CustomScriptManager.cpp
+++ b/Engine/Core/src/yougine/managers/CustomScriptManager.cpp
@@ -10,9 +10,9 @@ namespace yougine::managers
 
     void CustomScriptManager::InitializeMembers()
     {
-        for (GameObject* gameobject : componentlist->GetReferObjectList(ComponentName::kCustom))
+        for (components::Component* component : componentlist->GetReferObjectList(ComponentName::kCustom))
         {
-            for (components::Component* component : gameobject->GetComponents())
+            for (components::Component* component : component->GetGameObject()->GetComponents())
             {
                 component->InitializeOnPlayBack();
             }
@@ -21,9 +21,9 @@ namespace yougine::managers
 
     void CustomScriptManager::ExcuteCoponents()
     {
-        for (GameObject* gameObject : componentlist->GetObjectsDictionary()[ComponentName::kCustom])
+        for (components::Component* component : componentlist->GetObjectsDictionary()[ComponentName::kCustom])
         {
-            for (components::Component* component : gameObject->GetComponents())
+            for (components::Component* component : component->GetGameObject()->GetComponents())
             {
                 component->Excute();
             }


### PR DESCRIPTION
This closes #26
ComponentListの対象をGameObjectからComponentに変更し、GameObjectのRemoveComponentを使えるようにした