### PR TITLE
kNoneなクラスの名前の表示をクラス名が表示されるようにした

### DIFF
--- a/Engine/Core/src/yougine/Editor/ComponentViewer.cpp
+++ b/Engine/Core/src/yougine/Editor/ComponentViewer.cpp
@@ -28,7 +28,7 @@ namespace editor
             component_name = "CustomComponent";
             break;
         case yougine::managers::ComponentName::kNone:
-            component_name = "TransformComponent";
+            component_name = typeid(*component).name();
             break;
         default:
             break;


### PR DESCRIPTION
kNoneなクラスがすべてInspector上で"TransformComponent"となっていたのを、クラスの名前がひょうじされるようにした。"class yougine::components::TransformComponent"のように名前空間もつけて表示される