### PR TITLE
EditorWindowのメニューバーを多重階層に対応させた

### DIFF
--- a/Engine/Core/src/yougine/Editor/EditorWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/EditorWindow.cpp
@@ -20,11 +20,11 @@ namespace editor
     {
         if (ImGui::BeginMenuBar())
         {
-            for (std::string bar_label : menu_bar_list)
+            for (std::pair<std::string, std::vector<MenuItem*>> menu : pulldown_menu_bar->menu_items)
             {
-                if (ImGui::BeginMenu(bar_label.c_str()))
+                if (ImGui::BeginMenu(menu.first.c_str()))
                 {
-                    RenderMenuItems();
+                    RenderMenuItems(menu.second);
                     ImGui::EndMenu();
                 }
             }
@@ -33,11 +33,25 @@ namespace editor
         }
     }
 
-    void EditorWindow::RenderMenuItems()
+    void EditorWindow::RenderMenuItems(std::vector<MenuItem*> menu_items)
     {
-        for (std::string item : menu_item_list)
+        for (MenuItem* menu_item : menu_items)
         {
-            SelectedItemProcess(item);
+            for (std::pair<std::string, std::vector<MenuItem*>> item : menu_item->items)
+            {
+                if (item.second.empty())
+                {
+                    SelectedItemProcess(item.first);
+                }
+                else
+                {
+                    if (ImGui::BeginMenu(item.first.c_str()))
+                    {
+                        RenderMenuItems(item.second);
+                        ImGui::EndMenu();
+                    }
+                }
+            }
         }
     }
 

--- a/Engine/Core/src/yougine/Editor/EditorWindow.h
+++ b/Engine/Core/src/yougine/Editor/EditorWindow.h
@@ -7,14 +7,36 @@ namespace editor
     class EditorWindowsManager;
     enum class EditorWindowName;
 
+    /**
+     * \brief メニューバーの各項目が選択されたときその項目に属しているアイテムを表示する
+     * MenuItem自身から更にプルダウンするために, 自身の子供のMenuItemを持っている
+     *
+     * 子供のMenuItem*がnullのとき, SelectedItemProcessを呼び出してアイテム選択処理を実行する
+     *
+     * std::string ... アイテムの表示文字列
+     * MenuItem* ... 一つ下の子供
+     */
+    struct MenuItem
+    {
+        std::vector < std::pair<std::string, std::vector<MenuItem*>>> items;
+    };
+
+    /**
+     * \brief メニューバー(windowの上に出てくるプルダウンメニュー)
+     */
+    struct PullDownMenuBar
+    {
+        std::vector < std::pair< std::string, std::vector<MenuItem*>> > menu_items;
+    };
+
+
     class EditorWindow
     {
     protected:
         EditorWindowsManager* editor_windows_manager;
         EditorWindowName window_name;
         bool is_selected = false;
-        std::vector<std::string> menu_bar_list;
-        std::vector<std::string> menu_item_list;
+        PullDownMenuBar* pulldown_menu_bar;
 
     public:
         EditorWindow(EditorWindowsManager*, EditorWindowName);
@@ -23,7 +45,7 @@ namespace editor
     protected:
         void Setup();
         void RenderMenuBar();
-        virtual void RenderMenuItems();
+        void RenderMenuItems(std::vector<MenuItem*> menu_items);
         virtual void SelectedItemProcess(std::string item);
         virtual void InitializeMenuLists();
     };

--- a/Engine/Core/src/yougine/Editor/HierarchyWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/HierarchyWindow.cpp
@@ -14,15 +14,29 @@ namespace editor
 
     void HierarchyWindow::InitializeMenuLists()
     {
-        menu_bar_list =
-        {
-            "Creat",
-        };
+        MenuItem* item0 = new MenuItem();
+        std::vector<MenuItem*> c_item0(0);
+        item0->items.emplace_back(std::make_pair("GameObject", c_item0));
 
-        menu_item_list =
-        {
-            "GameObject",
-        };
+        // --- debug ---
+        MenuItem* item1 = new MenuItem();
+        std::vector<MenuItem*> c_item1;
+        MenuItem* item10 = new MenuItem();
+        MenuItem* item11 = new MenuItem();
+        std::vector<MenuItem*> c_item10(0);
+        item10->items.emplace_back(std::make_pair("Ghost", c_item10));
+        std::vector<MenuItem*> c_item11(0);
+        item11->items.emplace_back(std::make_pair("CC2", c_item11));
+        c_item1.push_back(item10);
+        c_item1.push_back(item11);
+        item1->items.emplace_back(std::make_pair("GameObject_test", c_item1));
+        // ------
+
+        pulldown_menu_bar = new PullDownMenuBar();
+        std::vector<MenuItem*> items;
+        items.push_back(item0);
+        items.push_back(item1);//
+        pulldown_menu_bar->menu_items.emplace_back(std::make_pair("Create", items));
     }
 
 
@@ -44,8 +58,11 @@ namespace editor
     {
         if (ImGui::MenuItem(item.c_str()))
         {
-            std::string o_name = selection_info->GetSelectObject() != nullptr ? selection_info->GetSelectObject()->GetName() + "_c" + std::to_string((selection_info->GetSelectObject()->GetChildObjects().size() + 1)) : "Obj" + std::to_string(scene->GetGameObjects().size() + 1);
-            CreateGameObject(o_name, selection_info->GetSelectObject());
+            if (item == "GameObject")
+            {
+                std::string o_name = selection_info->GetSelectObject() != nullptr ? selection_info->GetSelectObject()->GetName() + "_c" + std::to_string((selection_info->GetSelectObject()->GetChildObjects().size() + 1)) : "Obj" + std::to_string(scene->GetGameObjects().size() + 1);
+                CreateGameObject(o_name, selection_info->GetSelectObject());
+            }
         };
     }
 

--- a/Engine/Core/src/yougine/Editor/ShaderGraph/ShaderGraphWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/ShaderGraph/ShaderGraphWindow.cpp
@@ -9,17 +9,33 @@ namespace editor::shadergraph
 
     void ShaderGraphWindow::InitializeMenuLists()
     {
-        menu_bar_list =
-        {
-            "Add Node",
-        };
+        MenuItem* item00 = new MenuItem();
+        std::vector<MenuItem*> c_item0(0);
+        item00->items.emplace_back(std::make_pair("Debug / Sample Node", c_item0));
 
-        menu_item_list =
-        {
-            "Debug/Sample Node",
-            "Main/Unlit",
-            "Input/Vector3",
-        };
+        MenuItem* item01 = new MenuItem();
+        std::vector<MenuItem*> c_item01(0);
+        item01->items.emplace_back(std::make_pair("Main/Unlit", c_item01));
+
+        MenuItem* item02 = new MenuItem();
+        std::vector<MenuItem*> c_item02(0);
+        item02->items.emplace_back(std::make_pair("Input/Vector3", c_item02));
+
+        pulldown_menu_bar = new PullDownMenuBar();
+        std::vector<MenuItem*> items0;
+        items0.push_back(item00);
+        items0.push_back(item01);
+        items0.push_back(item02);
+        pulldown_menu_bar->menu_items.emplace_back(std::make_pair("Add Node", items0));
+
+
+        MenuItem* item10 = new MenuItem();
+        std::vector<MenuItem*> c_item10(0);
+        item10->items.emplace_back(std::make_pair("Update", c_item10));
+
+        std::vector<MenuItem*> items1;
+        items1.push_back(item10);
+        pulldown_menu_bar->menu_items.emplace_back(std::make_pair("ShaderOverwriter", items1));
     }
 
 


### PR DESCRIPTION
以前までの実装だとCreate>GameObjectのように2段階層しかできなかったが、n階層のメニューバーを作成できるように実装変更した