### PR TITLE
ビルド時にエディタとマテリアルが違う問題を修正

### DIFF
--- a/Engine/Core/CMakeLists.txt
+++ b/Engine/Core/CMakeLists.txt
@@ -46,4 +46,4 @@ add_library(YouginLib STATIC ${cppfiles})
 
 target_link_libraries(YouginLib opengl32 libglew32d glfw3)
 
-file(COPY ${PROJECT_SOURCE_DIR}/Resource DESTINATION ${CMAKE_BINARY_DIR}/Debug)
+#file(COPY ${PROJECT_SOURCE_DIR}/Resource DESTINATION ${CMAKE_BINARY_DIR}/Debug)

--- a/Engine/Core/Core.vcxproj
+++ b/Engine/Core/Core.vcxproj
@@ -171,6 +171,7 @@
     <ClCompile Include="src\yougine\Editor\InspectorWindows\AssetView\view\AssetView.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\Asset.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetDataBases\AssetDatabase.cpp" />
+    <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfos\AssetInfoFile.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfos\AssetInfoFileExporter.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetParameter\Parameter.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\CustomScripts\CustomScriptAsset.cpp" />
@@ -235,6 +236,7 @@
     <ClInclude Include="src\yougine\Editor\InspectorWindows\AssetView\view\AssetView.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\Asset.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetDataBases\AssetDatabase.h" />
+    <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfos\AssetInfoFile.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfos\AssetInfoFileExporter.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetParameter\Parameter.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\CustomScripts\CustomScriptAsset.h" />

--- a/Engine/Core/Core.vcxproj
+++ b/Engine/Core/Core.vcxproj
@@ -171,7 +171,7 @@
     <ClCompile Include="src\yougine\Editor\InspectorWindows\AssetView\view\AssetView.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\Asset.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetDataBases\AssetDatabase.cpp" />
-    <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfoExporter\AssetInfoFileExporter.cpp" />
+    <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfos\AssetInfoFileExporter.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetParameter\Parameter.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\CustomScripts\CustomScriptAsset.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\Material\Material.cpp" />
@@ -235,7 +235,7 @@
     <ClInclude Include="src\yougine\Editor\InspectorWindows\AssetView\view\AssetView.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\Asset.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetDataBases\AssetDatabase.h" />
-    <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfoExporter\AssetInfoFileExporter.h" />
+    <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfos\AssetInfoFileExporter.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetParameter\Parameter.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\CustomScripts\CustomScriptAsset.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\Material\Material.h" />

--- a/Engine/Core/Core.vcxproj.filters
+++ b/Engine/Core/Core.vcxproj.filters
@@ -45,7 +45,7 @@
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetParameter\Parameter.cpp" />
     <ClCompile Include="src\yougine\Editor\InspectorWindows\AssetView\view\AssetView.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\shader\ShaderFileAsset.cpp" />
-    <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfoExporter\AssetInfoFileExporter.cpp" />
+    <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfos\AssetInfoFileExporter.cpp" />
     <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetDataBases\AssetDatabase.cpp" />
     <ClCompile Include="src\yougine\Editor\ShaderGraph\ShaderfileOverwrite.cpp" />
     <ClCompile Include="src\yougine\Editor\ShaderGraph\Nodes\ShaderGraphNode.cpp" />
@@ -68,21 +68,6 @@
     <ClCompile Include="src\yougine\componentclassnames\ComponentClassNames.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\yougine\components\Component.cpp">
-      <Filter>ソース ファイル\src\yougine\components</Filter>
-    </ClCompile>
-    <ClCompile Include="src\yougine\managers\ComponentList.cpp">
-      <Filter>ソース ファイル\src\yougine\managers</Filter>
-    </ClCompile>
-    <ClCompile Include="src\yougine\managers\CustomScriptManager.cpp">
-      <Filter>ソース ファイル\src\yougine\managers</Filter>
-    </ClCompile>
-    <ClCompile Include="src\yougine\GameObject.cpp">
-      <Filter>ソース ファイル\src\yougine</Filter>
-    </ClCompile>
-    <ClCompile Include="src\yougine\Scene.cpp">
-      <Filter>ソース ファイル\src\yougine</Filter>
-    </ClCompile>
     <ClCompile Include="lib\imgui\imgui.cpp">
       <Filter>ソース ファイル\lib\imgui</Filter>
     </ClCompile>
@@ -112,12 +97,6 @@
     </ClCompile>
     <ClCompile Include="src\yougine\Editor\EditorWindowsManager.cpp">
       <Filter>ソース ファイル\src\yougine\Editor</Filter>
-    </ClCompile>
-    <ClCompile Include="src\yougine\components\TransformComponent.cpp">
-      <Filter>ソース ファイル\src\yougine\components</Filter>
-    </ClCompile>
-    <ClCompile Include="src\yougine\InputManager.cpp">
-      <Filter>ソース ファイル\src\yougine</Filter>
     </ClCompile>
     <ClCompile Include="src\yougine\components\TransformComponent.cpp">
       <Filter>ソース ファイル\src\yougine\components</Filter>
@@ -213,16 +192,9 @@
     <ClInclude Include="src\yougine\managers\GameManager.h" />
     <ClInclude Include="src\yougine\managers\IManager.h" />
     <ClInclude Include="src\yougine\managers\RenderManager.h" />
-    <ClInclude Include="src\yougine\components\Component.h" />
     <ClInclude Include="src\yougine\Editor\EditorWindow.h" />
     <ClInclude Include="src\yougine\Editor\EditorWindowsManager.h" />
     <ClInclude Include="src\yougine\Editor\HierarchyWindow.h" />
-    <ClInclude Include="src\yougine\InputManager.h" />
-    <ClInclude Include="src\yougine\managers\ComponentList.h" />
-    <ClInclude Include="src\yougine\managers\CustomScriptManager.h" />
-    <ClInclude Include="src\yougine\GameObject.h" />
-    <ClInclude Include="src\yougine\Scene.h" />
-    <ClInclude Include="src\yougine\components\TransformComponent.h" />
     <ClInclude Include="src\yougine\SceneFiles\SceneLoader.h" />
     <ClInclude Include="src\yougine\BuildScript\Builder.h" />
     <ClInclude Include="src\yougine\Editor\MenuBar.h" />
@@ -247,7 +219,6 @@
     <ClInclude Include="src\yougine\Editor\SceneWindow.h" />
     <ClInclude Include="src\yougine\components\RenderComponent.h" />
     <ClInclude Include="src\yougine\Editor\SelectionInfo.h" />
-    <ClInclude Include="src\yougine\Layer.h" />
     <ClInclude Include="src\yougine\managers\GameManager.h" />
     <ClInclude Include="src\yougine\managers\IManager.h" />
     <ClInclude Include="src\yougine\managers\RenderManager.h" />
@@ -274,7 +245,7 @@
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetParameter\Parameter.h" />
     <ClInclude Include="src\yougine\Editor\InspectorWindows\AssetView\view\AssetView.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\shader\ShaderFileAsset.h" />
-    <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfoExporter\AssetInfoFileExporter.h" />
+    <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfos\AssetInfoFileExporter.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetDataBases\AssetDatabase.h" />
     <ClInclude Include="src\yougine\Editor\ShaderGraph\Nodes\ShaderGraphInputNodes.h" />
     <ClInclude Include="src\yougine\components\TransformComponent.h" />
@@ -290,7 +261,6 @@
     <ClInclude Include="src\yougine\Editor\PropertiesInputField.h" />
     <ClInclude Include="src\yougine\Editor\ShaderGraph\ShaderGraphInputFieldViewer.h" />
     <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\CustomScripts\CustomScriptAsset.h" />
-    <ClInclude Include="src\yougine\utilitys\Quaternion.h" />
     <ClInclude Include="src\yougine\managers\ComponentExportParameterManager.h" />
     <ClInclude Include="src\yougine\components\ComponentExportParameters\ComponentExportParameter.h" />
     <ClInclude Include="src\yougine\componentclassnames\ComponentClassNames.h" />

--- a/Engine/Core/Core.vcxproj.filters
+++ b/Engine/Core/Core.vcxproj.filters
@@ -66,6 +66,7 @@
     <ClCompile Include="src\yougine\managers\ComponentExportParameterManager.cpp" />
     <ClCompile Include="src\yougine\components\ComponentExportParameters\ComponentExportParameter.cpp" />
     <ClCompile Include="src\yougine\componentclassnames\ComponentClassNames.cpp" />
+    <ClCompile Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfos\AssetInfoFile.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="lib\imgui\imgui.cpp">
@@ -264,6 +265,7 @@
     <ClInclude Include="src\yougine\managers\ComponentExportParameterManager.h" />
     <ClInclude Include="src\yougine\components\ComponentExportParameters\ComponentExportParameter.h" />
     <ClInclude Include="src\yougine\componentclassnames\ComponentClassNames.h" />
+    <ClInclude Include="src\yougine\Editor\ProjectWindows\Assets\element\Model\AssetInfos\AssetInfoFile.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="src\yougine\test.frag" />

--- a/Engine/Core/src/yougine/BuildScript/Builder.cpp
+++ b/Engine/Core/src/yougine/BuildScript/Builder.cpp
@@ -13,7 +13,7 @@ void builders::Builder::Build(std::string exportpath, yougine::Scene* scene)
     //シーンファイルのエクスポート（本来はeditor上の操作によりエクスポートしたい。
     //なんならビルド先にできるのおかしい。ビルド時にファイルコピーがされるべき）
     auto sceneexporter = new yougine::SceneFiles::SceneFileExporter();
-    auto projectpath = projects::Project::GetInstance()->projectFolderPath;
+    auto projectpath = projects::Project::GetInstance()->GetProjectFolderPath_ByTypeString();
     auto buildfolder = projectpath + "build\\";
     if (_mkdir(buildfolder.c_str()))
     {
@@ -41,7 +41,7 @@ void builders::Builder::Save(yougine::Scene* scene)
 {
     //シーンファイルのエクスポート（本来はeditor上の操作によりエクスポートしたい。
     //なんならビルド先にできるのおかしい。ビルド時にファイルコピーがされるべき）
-    auto projectpath = projects::Project::GetInstance()->projectFolderPath;
+    auto projectpath = projects::Project::GetInstance()->GetProjectFolderPath_ByTypeString();
     auto exportPath = projectpath + "build\\scene.json";
 
     auto sceneexporter = new yougine::SceneFiles::SceneFileExporter();

--- a/Engine/Core/src/yougine/BuildScript/Builder.cpp
+++ b/Engine/Core/src/yougine/BuildScript/Builder.cpp
@@ -20,7 +20,8 @@ void builders::Builder::Build(std::string exportpath, yougine::Scene* scene)
         std::cout << "buildフォルダ作成" << std::endl;
     }
 
-    sceneexporter->ScenefileExportFromScene(scene, projectpath + "build\\scene.json");
+    // sceneexporter->ScenefileExportFromScene(scene, projectpath + "build\\scene.json");
+    Save(scene);
 
     std::string exportpath_for_cmd = std::regex_replace(exportpath, std::regex("/"), "\\");
 
@@ -34,4 +35,15 @@ void builders::Builder::Build(std::string exportpath, yougine::Scene* scene)
     std::cout << cmd << std::endl;
     system(cmd.c_str());
     // system("rmdir /S /Q .\\tmpbuild");
+}
+
+void builders::Builder::Save(yougine::Scene* scene)
+{
+    //シーンファイルのエクスポート（本来はeditor上の操作によりエクスポートしたい。
+    //なんならビルド先にできるのおかしい。ビルド時にファイルコピーがされるべき）
+    auto projectpath = projects::Project::GetInstance()->projectFolderPath;
+    auto exportPath = projectpath + "build\\scene.json";
+
+    auto sceneexporter = new yougine::SceneFiles::SceneFileExporter();
+    sceneexporter->ScenefileExportFromScene(scene, exportPath);
 }

--- a/Engine/Core/src/yougine/BuildScript/Builder.cpp
+++ b/Engine/Core/src/yougine/BuildScript/Builder.cpp
@@ -23,15 +23,23 @@ void builders::Builder::Build(std::string exportpath, yougine::Scene* scene)
     // sceneexporter->ScenefileExportFromScene(scene, projectpath + "build\\scene.json");
     Save(scene);
 
+
+
+
     std::string exportpath_for_cmd = std::regex_replace(exportpath, std::regex("/"), "\\");
+
+    //リソースファイルをコピー
+    std::string resourcefolder = "./Resource/";
+    std::filesystem::copy(resourcefolder, exportpath_for_cmd + "/Resource", std::filesystem::copy_options::overwrite_existing | std::filesystem::copy_options::recursive);
+
 
     auto cmakepath = "";
     std::string cddirectoryCMD = "dir&mkdir tmpbuild & cd tmpbuild & mkdir build & cd build";
     std::string cmakebuildcmd =
         "cmake .\\..\\..\\..\\GameBuildProject -G\"Visual Studio 16 2019\" & cmake --build .";
-    std::string copyDebugfolderToExortoathcmd = "xcopy Debug " + exportpath_for_cmd + " /s /y";
+    // std::string copyDebugfolderToExortoathcmd = "xcopy Debug " + exportpath_for_cmd + " /s /y";
     std::string runcmd = "cd " + exportpath_for_cmd + " & " + "ExeProject.exe";
-    std::string cmd = cddirectoryCMD + " & " + cmakebuildcmd + " & " + copyDebugfolderToExortoathcmd + " & " + runcmd;
+    std::string cmd = cddirectoryCMD + " & " + cmakebuildcmd + " & " + runcmd;
     std::cout << cmd << std::endl;
     system(cmd.c_str());
     // system("rmdir /S /Q .\\tmpbuild");

--- a/Engine/Core/src/yougine/BuildScript/Builder.cpp
+++ b/Engine/Core/src/yougine/BuildScript/Builder.cpp
@@ -37,9 +37,9 @@ void builders::Builder::Build(std::string exportpath, yougine::Scene* scene)
     std::string cddirectoryCMD = "dir&mkdir tmpbuild & cd tmpbuild & mkdir build & cd build";
     std::string cmakebuildcmd =
         "cmake .\\..\\..\\..\\GameBuildProject -G\"Visual Studio 16 2019\" & cmake --build .";
-    // std::string copyDebugfolderToExortoathcmd = "xcopy Debug " + exportpath_for_cmd + " /s /y";
-    std::string runcmd = "cd " + exportpath_for_cmd + " & " + "ExeProject.exe";
-    std::string cmd = cddirectoryCMD + " & " + cmakebuildcmd + " & " + runcmd;
+    std::string copyDebugfolderToExortoathcmd = "xcopy Debug " + exportpath_for_cmd + " /s /y";
+    std::string runcmd = "cd " + exportpath_for_cmd + " & " + "ExeProject.exe &";
+    std::string cmd = cddirectoryCMD + " & " + cmakebuildcmd + " & " + copyDebugfolderToExortoathcmd + " & " + runcmd;
     std::cout << cmd << std::endl;
     system(cmd.c_str());
     // system("rmdir /S /Q .\\tmpbuild");

--- a/Engine/Core/src/yougine/BuildScript/Builder.h
+++ b/Engine/Core/src/yougine/BuildScript/Builder.h
@@ -12,5 +12,6 @@ namespace builders
          * \brief
          */
         void Build(std::string exportpath, yougine::Scene* scene);
+        void Save(yougine::Scene* scene);
     };
 }

--- a/Engine/Core/src/yougine/Editor/InspectorWindows/AssetView/view/AssetView.cpp
+++ b/Engine/Core/src/yougine/Editor/InspectorWindows/AssetView/view/AssetView.cpp
@@ -1,6 +1,7 @@
 ﻿#include "AssetView.h"
 
 #include <iostream>
+#include <memory>
 #include <valarray>
 
 #include "../../../../Projects/Project.h"
@@ -135,7 +136,8 @@ AssetView::AssetView::AssetView(std::shared_ptr<editor::projectwindows::assets::
                 if (template_name == "class std::shared_ptr<class editor::projectwindows::assets::elements::model::materials::shaderinputparameters::ShaderInputAndTypeStruct>")
                 {
                     namespace  shaderinputstruct_namespace = editor::projectwindows::assets::elements::model::materials::shaderinputparameters;
-                    std::vector<std::shared_ptr<shaderinputstruct_namespace::ShaderInputAndTypeStruct>> vec_shaderinput = std::any_cast<std::vector<std::shared_ptr<shaderinputstruct_namespace::ShaderInputAndTypeStruct>>>(value);
+                    std::vector<std::shared_ptr<shaderinputstruct_namespace::ShaderInputAndTypeStruct>>* vec_shaderinput
+                        = std::any_cast<std::vector<std::shared_ptr<shaderinputstruct_namespace::ShaderInputAndTypeStruct>>*>(value);
                     std::cout << "class std::shared_ptr<class editor::projectwindows::assets::elements::model::materials::shaderinputparameters::ShaderInputAndTypeStruct>!!" << std::endl;
                     this->parameter_vec.emplace_back(std::make_shared <utility::view::parameters::ShaderInputParameterView>(vec_shaderinput));
                 }

--- a/Engine/Core/src/yougine/Editor/MenuBar.cpp
+++ b/Engine/Core/src/yougine/Editor/MenuBar.cpp
@@ -31,6 +31,11 @@ void editor::MenuBar::Draw()
 
     ImGui::InputText("exportpath", buildexportpath, 256);
     ImGui::InputText("scenefilepath", sceenfilepath, 256);
+    if (ImGui::Button("save"))
+    {
+        auto builder = new builders::Builder();
+        builder->Save(scene);
+    }
 
     if (ImGui::Button("Play"))
     {

--- a/Engine/Core/src/yougine/Editor/MenuBar.cpp
+++ b/Engine/Core/src/yougine/Editor/MenuBar.cpp
@@ -6,10 +6,10 @@
 editor::MenuBar::MenuBar(EditorWindowsManager* editor_windows_manager, yougine::Scene* scene) : EditorWindow(editor_windows_manager, editor::EditorWindowName::MenuBar)
 {
     //ビルド先のぱす（初期値だが、とりあえず）
-    auto buildpath = projects::Project::GetInstance()->projectFolderPath + "build";
+    auto buildpath = projects::Project::GetInstance()->GetProjectFolderPath_ByTypeString() + "build";
     strcpy_s(buildexportpath, buildpath.c_str());
     //シーンファイルの参照（本来はプロジェクトのフォルダーにあるのを、ビルド時に選択、エクスポートが正しいが、今回は既にビルドさきにあるものとする）
-    auto scenefilepath = projects::Project::GetInstance()->projectFolderPath + "build\scene.json";
+    auto scenefilepath = projects::Project::GetInstance()->GetProjectFolderPath_ByTypeString() + "build\scene.json";
     strcpy_s(sceenfilepath, scenefilepath.c_str());
     this->scene = scene;
 

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.cpp
@@ -52,6 +52,11 @@ std::shared_ptr<utility::youginuuid::YougineUuid> editor::projectwindows::assets
     return this->uuid;
 }
 
+const std::filesystem::path editor::projectwindows::assets::elements::model::Asset::GetFilePath()
+{
+    return this->path;
+}
+
 void editor::projectwindows::assets::elements::model::Asset::SwapParameter(std::string parameter_name,
     std::shared_ptr<assetparameters::Parameter> parameter)
 {

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <memory>
 
 editor::projectwindows::assets::elements::model::Asset::Asset(std::filesystem::path path, std::shared_ptr<utility::youginuuid::YougineUuid> uuid)
 {
@@ -21,13 +22,14 @@ editor::projectwindows::assets::elements::model::Asset::Asset(const std::filesys
     this->path = assetinfo_file_path.parent_path().string() + "\\" + assetinfo_file_path.stem().string();
     using json = nlohmann::ordered_json;
 
-    std::ifstream reading(assetinfo_file_path.string(), std::ios::in);
+    // std::ifstream reading(assetinfo_file_path.string(), std::ios::in);
+    //
+    // json o_json;
+    // reading >> o_json;
 
-    json o_json;
-    reading >> o_json;
-
-    if (o_json.contains("uuid")) {
-        std::string asset_id = o_json["uuid"];
+    this->asset_info = std::make_shared<assetinfos::AssetInfoFile>(assetinfo_file_path);
+    if (asset_info->IsContainValue("uuid")) {
+        std::string asset_id = asset_info->GetParameter("uuid");
         this->uuid = std::shared_ptr<utility::youginuuid::YougineUuid>(new utility::youginuuid::YougineUuid(asset_id));
     }
     else

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.h
@@ -33,7 +33,7 @@ namespace editor::projectwindows::assets::elements::model
         std::map<std::string, std::shared_ptr<assetparameters::Parameter>> GetParameter();
         virtual void Export() = 0;
         std::shared_ptr<utility::youginuuid::YougineUuid> GetAssetId();
-
+        const std::filesystem::path GetFilePath();
         void SwapParameter(std::string parameter_name, std::shared_ptr<assetparameters::Parameter> parameter);
 
         // template <class fieldType>

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 
+#include "AssetInfos/AssetInfoFile.h"
 #include "UserShare/utilitys/uuid/YougineUuid.h"
 #include "AssetParameter/Parameter.h"
 
@@ -25,6 +26,7 @@ namespace editor::projectwindows::assets::elements::model
         std::filesystem::path assetinfo_filepath;
         bool is_assetinfo_file_exist;
         std::shared_ptr<utility::youginuuid::YougineUuid> uuid;
+        std::shared_ptr<assetinfos::AssetInfoFile> asset_info;
     public:
         Asset(std::filesystem::path path, std::shared_ptr<utility::youginuuid::YougineUuid> uuid);
         Asset(const std::filesystem::path assetinfo_file_path);

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetDataBases/AssetDatabase.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetDataBases/AssetDatabase.cpp
@@ -30,6 +30,20 @@ std::shared_ptr<editor::projectwindows::assets::elements::model::Asset> editor::
     return this->asset_map[assetid];
 }
 
+std::shared_ptr<editor::projectwindows::assets::elements::model::Asset> editor::projectwindows::assets::elements::model
+::assetdatabases::AssetDatabase::GetAssetFromFilePath(std::filesystem::path assetpath)
+{
+    for (auto asset_map : this->asset_map)
+    {
+        auto asset = asset_map.second;
+        if (asset->GetFilePath() == assetpath)
+        {
+            return asset;
+        }
+    }
+    return nullptr;
+}
+
 std::unordered_map<std::string, std::shared_ptr<editor::projectwindows::assets::elements::model::Asset>, utility::
     youginuuid::Hash> editor::projectwindows::assets::elements::model::assetdatabases::AssetDatabase::GetAssetList()
 {

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetDataBases/AssetDatabase.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetDataBases/AssetDatabase.h
@@ -15,6 +15,13 @@ namespace editor::projectwindows::assets::elements::model::assetdatabases
         AssetDatabase();
         void AddAsset(std::shared_ptr<utility::youginuuid::YougineUuid> uuid, std::shared_ptr<Asset> asset);
         std::shared_ptr<Asset> GetAsset(std::string assetid);
+
+        /**
+         * \brief ファイルパスからアセットを全探索。（全探索するのであまり使いたくない）
+         * \param assetpath 探索対象のファイルパス
+         * \return
+         */
+        std::shared_ptr<Asset> GetAssetFromFilePath(std::filesystem::path assetpath);
         std::unordered_map<std::string, std::shared_ptr<Asset>, utility::youginuuid::Hash> GetAssetList();
     };
 }

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.cpp
@@ -17,7 +17,7 @@ editor::projectwindows::assets::elements::model::assetinfos::AssetInfoFile::Asse
 
 }
 
-std::string editor::projectwindows::assets::elements::model::assetinfos::AssetInfoFile::GetParameter(
+nlohmann::basic_json<> editor::projectwindows::assets::elements::model::assetinfos::AssetInfoFile::GetParameter(
     std::string parameterName)
 {
     return (*json)[parameterName];

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.cpp
@@ -1,1 +1,30 @@
 ﻿#include "AssetInfoFile.h"
+#include <tinygltf/json.hpp>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <memory>
+
+editor::projectwindows::assets::elements::model::assetinfos::AssetInfoFile::AssetInfoFile(const std::filesystem::path assetinfofilePath)
+{
+    std::ifstream reading(assetinfofilePath.string(), std::ios::in);
+
+    json = std::make_shared<nlohmann::json>();
+    nlohmann::json o_json;
+    reading >> o_json;
+    json = std::make_shared<nlohmann::json>(o_json);
+
+}
+
+std::string editor::projectwindows::assets::elements::model::assetinfos::AssetInfoFile::GetParameter(
+    std::string parameterName)
+{
+    return (*json)[parameterName];
+}
+
+bool editor::projectwindows::assets::elements::model::assetinfos::AssetInfoFile::IsContainValue(
+    std::string parameterName)
+{
+    return json->contains(parameterName);
+}

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.cpp
@@ -1,0 +1,1 @@
+﻿#include "AssetInfoFile.h"

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.h
@@ -1,9 +1,22 @@
 ﻿#pragma once
+#include <filesystem>
+#include <string>
+#include <tinygltf/json.hpp>
+
 namespace editor::projectwindows::assets::elements::model::assetinfos
 {
     class AssetInfoFile
     {
-    public:
+    private:
+        std::shared_ptr<nlohmann::json> json;
 
+    public:
+        AssetInfoFile(const std::filesystem::path assetinfofilePath);
+        std::string GetParameter(std::string parameterName);
+
+        /**
+         * \brief parameterNameというパラメータがあるかを返す
+         */
+        bool IsContainValue(std::string parameterName);
     };
 }

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.h
@@ -12,7 +12,7 @@ namespace editor::projectwindows::assets::elements::model::assetinfos
 
     public:
         AssetInfoFile(const std::filesystem::path assetinfofilePath);
-        std::string GetParameter(std::string parameterName);
+        nlohmann::basic_json<> GetParameter(std::string parameterName);
 
         /**
          * \brief parameterNameというパラメータがあるかを返す

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFile.h
@@ -1,0 +1,9 @@
+﻿#pragma once
+namespace editor::projectwindows::assets::elements::model::assetinfos
+{
+    class AssetInfoFile
+    {
+    public:
+
+    };
+}

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFileExporter.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFileExporter.cpp
@@ -3,7 +3,7 @@
 #include <fstream>
 #include <tinygltf/json.hpp>
 
-void editor::projectwindows::assets::elements::model::assetinfofileexporter::AssetInfoFileExporter::AssetInfoFileExporter::ExportAssetInfoFile(std::filesystem::path targetAssetFilePath, nlohmann::json target_json)
+void editor::projectwindows::assets::elements::model::assetinfos::AssetInfoFileExporter::AssetInfoFileExporter::ExportAssetInfoFile(std::filesystem::path targetAssetFilePath, nlohmann::json target_json)
 {
     std::ofstream writing_file;
     auto assetfilename = targetAssetFilePath.filename().string() + ".assetinfo";

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFileExporter.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/AssetInfos/AssetInfoFileExporter.h
@@ -2,7 +2,7 @@
 #include <filesystem>
 #include <tinygltf/json.hpp>
 
-namespace editor::projectwindows::assets::elements::model::assetinfofileexporter
+namespace editor::projectwindows::assets::elements::model::assetinfos
 {
     class AssetInfoFileExporter
     {

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/CustomScripts/CustomScriptAsset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/CustomScripts/CustomScriptAsset.cpp
@@ -10,7 +10,7 @@ void editor::projectwindows::assets::elements::model::customscript::CustomScript
     json[GETVALUENAME(uuid)] = uuid->convertstring();
     json[GETVALUENAME(scriptname)] = scriptname;
 
-    auto exporter = std::make_shared<assetinfofileexporter::AssetInfoFileExporter>();
+    auto exporter = std::make_shared<assetinfos::AssetInfoFileExporter>();
     exporter->ExportAssetInfoFile(this->path, json);
 }
 

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/CustomScripts/CustomScriptAsset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/CustomScripts/CustomScriptAsset.cpp
@@ -2,7 +2,7 @@
 
 #include <tinygltf/json.hpp>
 
-#include "../AssetInfoExporter/AssetInfoFileExporter.h"
+#include "../AssetInfos//AssetInfoFileExporter.h"
 
 void editor::projectwindows::assets::elements::model::customscript::CustomScriptAsset::Export()
 {

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
@@ -15,13 +15,14 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
     this->parameter["path"] = std::make_shared<assetparameters::Parameter>(this->path.string(), onlydisplay_option);
     this->parameter[GETVALUENAME(uuid)] = std::make_shared<assetparameters::Parameter>(uuid->convertstring(), onlydisplay_option);
 
+    //fragment shader　設定
     auto fragment_assetoption = std::make_shared<option_type>(false, false, true);
     // auto fragassetset_function
     //     = this->Generate_Field_SwitchFunction(&frag_asset_uuid, fragment_assetoption,
     //         GETVALUENAME(frag_asset_uuid));
     auto fragassetset_function
-        = this->Generate_Field_SwitchFunction_Template<shader::ShaderFileAsset>(&frag_asset_uuid, fragment_assetoption,
-            GETVALUENAME(frag_asset_uuid));
+        = this->Generate_Field_SwitchFunction_Template<shader::ShaderFileAsset>(&frag_asset, fragment_assetoption,
+            GETVALUENAME(frag_asset));
     fragment_assetoption->SetInputAction(fragassetset_function);
     // fragment_assetoption->SetInputAction([&, fragment_assetoption](std::shared_ptr<editor::projectwindows::assets::elements::model::Asset> input)
     //     {
@@ -36,16 +37,17 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
     //             this->SwapParameter(GETVALUENAME(frag_asset_uuid), std::make_shared<assetparameters::Parameter>(frag_asset_uuid->GetAssetId(), fragment_assetoption));
     //         }
     //     });
-    this->parameter[GETVALUENAME(frag_asset_uuid)] = std::make_shared<assetparameters::Parameter>(frag_asset_uuid->GetAssetId(), fragment_assetoption);
+    this->parameter[GETVALUENAME(frag_asset)] = std::make_shared<assetparameters::Parameter>(frag_asset->GetAssetId(), fragment_assetoption);
 
+    //vertexshader 設定
     auto vertex_assetoption = std::make_shared<option_type>(false, false, true);
     auto vert_function
-        = this->Generate_Field_SwitchFunction(&vert_asset_uuid, vertex_assetoption,
-            GETVALUENAME(vert_asset_uuid));
+        = this->Generate_Field_SwitchFunction(&vert_asset, vertex_assetoption,
+            GETVALUENAME(vert_asset));
 
     vertex_assetoption->SetInputAction(vert_function);
 
-    this->parameter[GETVALUENAME(vert_asset_uuid)] = std::make_shared<assetparameters::Parameter>(vert_asset_uuid->GetAssetId(), vertex_assetoption);
+    this->parameter[GETVALUENAME(vert_asset)] = std::make_shared<assetparameters::Parameter>(vert_asset->GetAssetId(), vertex_assetoption);
 
     auto shaderinputs_assetoption = std::make_shared<option_type>(false, false, false);
 
@@ -111,28 +113,28 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
         std::string vertname = GETVALUENAME(vert_asset_uuid);
         if (this->asset_info->IsContainValue(vertname)) {
             std::string asset_id = asset_info->GetParameter(vertname);
-            this->vert_asset_uuid = std::dynamic_pointer_cast<shader::ShaderFileAsset>(projects::Project::GetInstance()->GetDataBase()->GetAsset(asset_id));
+            this->vert_asset = std::dynamic_pointer_cast<shader::ShaderFileAsset>(projects::Project::GetInstance()->GetDataBase()->GetAsset(asset_id));
         }
         else
         {
-            vert_asset_uuid = shader::ShaderFileAsset::GetDefaultVertexShader();
+            vert_asset = shader::ShaderFileAsset::GetDefaultVertexShader();
         }
 
         //fragmentshaderのアセットを取得
         std::string fragname = GETVALUENAME(frag_asset_uuid);
         if (asset_info->IsContainValue(fragname)) {
             std::string asset_id = asset_info->GetParameter(fragname);
-            this->frag_asset_uuid = std::dynamic_pointer_cast<shader::ShaderFileAsset>(projects::Project::GetInstance()->GetDataBase()->GetAsset(asset_id));
+            this->frag_asset = std::dynamic_pointer_cast<shader::ShaderFileAsset>(projects::Project::GetInstance()->GetDataBase()->GetAsset(asset_id));
         }
         else
         {
-            frag_asset_uuid = shader::ShaderFileAsset::GetDefaultFragmentShader();
+            frag_asset = shader::ShaderFileAsset::GetDefaultFragmentShader();
         }
     }
     else
     {
-        frag_asset_uuid = shader::ShaderFileAsset::GetDefaultFragmentShader();
-        vert_asset_uuid = shader::ShaderFileAsset::GetDefaultVertexShader();
+        frag_asset = shader::ShaderFileAsset::GetDefaultFragmentShader();
+        vert_asset = shader::ShaderFileAsset::GetDefaultVertexShader();
     }
     Initialize();
 }
@@ -155,9 +157,9 @@ void editor::projectwindows::assets::elements::model::materials::Material::Expor
 {
     nlohmann::json json;
     json[GETVALUENAME(uuid)] = uuid->convertstring();
-    if (vert_asset_uuid && frag_asset_uuid) {
-        json[GETVALUENAME(vert_asset_uuid)] = vert_asset_uuid->GetAssetId()->convertstring();
-        json[GETVALUENAME(frag_asset_uuid)] = frag_asset_uuid->GetAssetId()->convertstring();
+    if (vert_asset && frag_asset) {
+        json[GETVALUENAME(vert_asset_uuid)] = vert_asset->GetAssetId()->convertstring();
+        json[GETVALUENAME(frag_asset_uuid)] = frag_asset->GetAssetId()->convertstring();
     }
 
     //シェーダへの入力パラメータをエクスポート(変数jsonに書き込む)
@@ -227,11 +229,11 @@ assets::elements::model::materials::Material::Generate_Field_SwitchFunction(
         // std::cout << typeid(field).name() << std::endl;
         if (input_cast_ptr)
         {
-            std::cout << this->frag_asset_uuid->GetAssetId()->convertstring() << std::endl;
+            std::cout << this->frag_asset->GetAssetId()->convertstring() << std::endl;
             *field = input_cast_ptr;
             auto parameter = std::make_shared<assetparameters::Parameter>((*field)->GetAssetId(), option);
             SwapParameter(parameter_name, std::make_shared<assetparameters::Parameter>((*field)->GetAssetId(), option));
-            std::cout << this->frag_asset_uuid->GetAssetId()->convertstring() << std::endl;
+            std::cout << this->frag_asset->GetAssetId()->convertstring() << std::endl;
         }
         else
         {
@@ -244,13 +246,13 @@ assets::elements::model::materials::Material::Generate_Field_SwitchFunction(
 std::shared_ptr<editor::projectwindows::assets::elements::model::shader::ShaderFileAsset> editor::projectwindows::assets
 ::elements::model::materials::Material::GetVertexShader()
 {
-    return this->vert_asset_uuid;
+    return this->vert_asset;
 }
 
 std::shared_ptr<editor::projectwindows::assets::elements::model::shader::ShaderFileAsset> editor::projectwindows::assets
 ::elements::model::materials::Material::GetFragmentShader()
 {
-    return this->frag_asset_uuid;
+    return this->frag_asset;
 }
 
 std::vector<std::shared_ptr<editor::projectwindows::assets::elements::model::materials::shaderinputparameters::

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
@@ -7,7 +7,7 @@
 #include <memory>
 
 #include "../../../../../../Projects/Project.h"
-#include "../AssetInfoExporter/AssetInfoFileExporter.h"
+#include "../AssetInfos//AssetInfoFileExporter.h"
 using option_type = editor::inspectorwindows::assetviews::options::AssetViewOption;
 void editor::projectwindows::assets::elements::model::materials::Material::Initialize()
 {

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
@@ -158,8 +158,8 @@ void editor::projectwindows::assets::elements::model::materials::Material::Expor
     nlohmann::json json;
     json[GETVALUENAME(uuid)] = uuid->convertstring();
     if (vert_asset && frag_asset) {
-        json[GETVALUENAME(vert_asset_uuid)] = vert_asset->GetAssetId()->convertstring();
-        json[GETVALUENAME(frag_asset_uuid)] = frag_asset->GetAssetId()->convertstring();
+        json[GETVALUENAME(vert_asset)] = vert_asset->GetAssetId()->convertstring();
+        json[GETVALUENAME(frag_asset)] = frag_asset->GetAssetId()->convertstring();
     }
 
     //シェーダへの入力パラメータをエクスポート(変数jsonに書き込む)

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
@@ -47,13 +47,43 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
 
     this->parameter[GETVALUENAME(vert_asset_uuid)] = std::make_shared<assetparameters::Parameter>(vert_asset_uuid->GetAssetId(), vertex_assetoption);
 
+    auto propertys = this->asset_info->GetParameter(key_property);
+    std::cout << propertys.dump() << std::endl;
+
     auto shaderinputs_assetoption = std::make_shared<option_type>(false, false, false);
-    auto f = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kFloat, "c", 3.0f);
-    shader_input_parameters.emplace_back(f);
-    auto f2 = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kInt, "sample_int", 45);
-    shader_input_parameters.emplace_back(f2);
-    auto ve3_color = std::make_shared<shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kVec3, "color_vec3", utility::Vector3(1, 1, 1));
-    shader_input_parameters.emplace_back(ve3_color);
+    for (auto property : propertys)
+    {
+        std::shared_ptr<shaderinputparameters::ShaderInputAndTypeStruct> parameter;
+        ShaderInputParameterType type;
+        if (property[this->key_valuetype] == key_int)
+        {
+            type = ShaderInputParameterType::kInt;
+            parameter = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>
+                (type, property[key_valuename], property[key_values][key_value].get<int>());
+        }
+        else if (property[this->key_valuetype] == key_float)
+        {
+            type = ShaderInputParameterType::kFloat;
+            parameter = std::make_shared
+                <shaderinputparameters::ShaderInputAndTypeStruct>(type, property[key_valuename], property[key_values][key_value].get<float>());
+        }
+        else if (property[this->key_valuetype] == key_vec3)
+        {
+            type = ShaderInputParameterType::kVec3;
+            utility::Vector3 vec3 = utility::Vector3(property[key_values]["x"].get<float>(), property[key_values]["y"].get<float>(), property[key_values]["z"].get<float>());
+            parameter = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>(type, property[key_valuename], vec3);
+        }
+        shader_input_parameters.emplace_back(parameter);
+
+
+    }
+
+    // auto f = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kFloat, "c", 3.0f);
+    // shader_input_parameters.emplace_back(f);
+    // auto f2 = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kInt, "sample_int", 45);
+    // shader_input_parameters.emplace_back(f2);
+    // auto ve3_color = std::make_shared<shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kVec3, "color_vec3", utility::Vector3(1, 1, 1));
+    // shader_input_parameters.emplace_back(ve3_color);
     this->parameter[GETVALUENAME(shader_input_parameters)] = std::make_shared<assetparameters::Parameter>(shader_input_parameters, shaderinputs_assetoption);;
 }
 
@@ -72,16 +102,11 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
     //assetinfoファイルある場合
     if (is_assetinfo_file_exist)
     {
-        using json = nlohmann::ordered_json;
 
-        std::ifstream reading(assetinfo_filepath.string(), std::ios::in);
-
-        json o_json;
-        reading >> o_json;
-
+        //vertexshaderのアセットを取得
         std::string vertname = GETVALUENAME(vert_asset_uuid);
-        if (o_json.contains(vertname)) {
-            std::string asset_id = o_json[vertname];
+        if (this->asset_info->IsContainValue(vertname)) {
+            std::string asset_id = asset_info->GetParameter(vertname);
             this->vert_asset_uuid = std::dynamic_pointer_cast<shader::ShaderFileAsset>(projects::Project::GetInstance()->GetDataBase()->GetAsset(asset_id));
         }
         else
@@ -89,9 +114,10 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
             vert_asset_uuid = shader::ShaderFileAsset::GetDefaultVertexShader();
         }
 
+        //fragmentshaderのアセットを取得
         std::string fragname = GETVALUENAME(frag_asset_uuid);
-        if (o_json.contains(fragname)) {
-            std::string asset_id = o_json[fragname];
+        if (asset_info->IsContainValue(fragname)) {
+            std::string asset_id = asset_info->GetParameter(fragname);
             this->frag_asset_uuid = std::dynamic_pointer_cast<shader::ShaderFileAsset>(projects::Project::GetInstance()->GetDataBase()->GetAsset(asset_id));
         }
         else
@@ -130,6 +156,45 @@ void editor::projectwindows::assets::elements::model::materials::Material::Expor
         json[GETVALUENAME(frag_asset_uuid)] = frag_asset_uuid->GetAssetId()->convertstring();
     }
 
+    //シェーダへの入力パラメータをエクスポート(変数jsonに書き込む)
+
+
+    int property_index = 0;
+    nlohmann::json json_propertylist;
+    for (auto shader_input_and_type_struct : shader_input_parameters)
+    {
+        auto valuename = *shader_input_and_type_struct->GetName();
+
+        nlohmann::json tmp_property_json;
+        //intの場合
+        if (shader_input_and_type_struct->GetValueType() == ShaderInputParameterType::kInt)
+        {
+            tmp_property_json[key_value] = *shader_input_and_type_struct->Get_int_value();
+            json_propertylist[property_index][key_valuetype] = "int";
+        }
+        //floatの場合
+        if (shader_input_and_type_struct->GetValueType() == ShaderInputParameterType::kFloat)
+        {
+            tmp_property_json[key_value] = *shader_input_and_type_struct->Get_float_value();
+            json_propertylist[property_index][key_valuetype] = "float";
+        }
+        //vec3の場合
+        if (shader_input_and_type_struct->GetValueType() == ShaderInputParameterType::kVec3)
+        {
+            auto value = shader_input_and_type_struct->Get_vec3_value();
+            tmp_property_json["x"] = value->x;
+            tmp_property_json["y"] = value->y;
+            tmp_property_json["z"] = value->z;
+            json_propertylist[property_index][key_valuetype] = "Vector3";
+        }
+        json_propertylist[property_index][key_valuename] = valuename;
+        json_propertylist[property_index][key_values] = tmp_property_json;
+
+        property_index++;
+    }
+    json["property"] = json_propertylist;
+
+    //エクスポート
     auto exporter = std::make_shared<assetinfos::AssetInfoFileExporter>();
     exporter->ExportAssetInfoFile(this->path, json);
 

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
@@ -130,7 +130,7 @@ void editor::projectwindows::assets::elements::model::materials::Material::Expor
         json[GETVALUENAME(frag_asset_uuid)] = frag_asset_uuid->GetAssetId()->convertstring();
     }
 
-    auto exporter = std::make_shared<assetinfofileexporter::AssetInfoFileExporter>();
+    auto exporter = std::make_shared<assetinfos::AssetInfoFileExporter>();
     exporter->ExportAssetInfoFile(this->path, json);
 
 }

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
@@ -110,7 +110,7 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
     {
 
         //vertexshaderのアセットを取得
-        std::string vertname = GETVALUENAME(vert_asset_uuid);
+        std::string vertname = GETVALUENAME(vert_asset);
         if (this->asset_info->IsContainValue(vertname)) {
             std::string asset_id = asset_info->GetParameter(vertname);
             this->vert_asset = std::dynamic_pointer_cast<shader::ShaderFileAsset>(projects::Project::GetInstance()->GetDataBase()->GetAsset(asset_id));
@@ -121,7 +121,7 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
         }
 
         //fragmentshaderのアセットを取得
-        std::string fragname = GETVALUENAME(frag_asset_uuid);
+        std::string fragname = GETVALUENAME(frag_asset);
         if (asset_info->IsContainValue(fragname)) {
             std::string asset_id = asset_info->GetParameter(fragname);
             this->frag_asset = std::dynamic_pointer_cast<shader::ShaderFileAsset>(projects::Project::GetInstance()->GetDataBase()->GetAsset(asset_id));

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
@@ -47,43 +47,47 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
 
     this->parameter[GETVALUENAME(vert_asset_uuid)] = std::make_shared<assetparameters::Parameter>(vert_asset_uuid->GetAssetId(), vertex_assetoption);
 
-    auto propertys = this->asset_info->GetParameter(key_property);
-    std::cout << propertys.dump() << std::endl;
-
     auto shaderinputs_assetoption = std::make_shared<option_type>(false, false, false);
-    for (auto property : propertys)
+
+    if (is_assetinfo_file_exist) {
+        auto propertys = this->asset_info->GetParameter(key_property);
+        std::cout << propertys.dump() << std::endl;
+
+        for (auto property : propertys)
+        {
+            std::shared_ptr<shaderinputparameters::ShaderInputAndTypeStruct> parameter;
+            ShaderInputParameterType type;
+            if (property[this->key_valuetype] == key_int)
+            {
+                type = ShaderInputParameterType::kInt;
+                parameter = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>
+                    (type, property[key_valuename], property[key_values][key_value].get<int>());
+            }
+            else if (property[this->key_valuetype] == key_float)
+            {
+                type = ShaderInputParameterType::kFloat;
+                parameter = std::make_shared
+                    <shaderinputparameters::ShaderInputAndTypeStruct>(type, property[key_valuename], property[key_values][key_value].get<float>());
+            }
+            else if (property[this->key_valuetype] == key_vec3)
+            {
+                type = ShaderInputParameterType::kVec3;
+                utility::Vector3 vec3 = utility::Vector3(property[key_values]["x"].get<float>(), property[key_values]["y"].get<float>(), property[key_values]["z"].get<float>());
+                parameter = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>(type, property[key_valuename], vec3);
+            }
+            shader_input_parameters.emplace_back(parameter);
+        }
+    }
+    else
     {
-        std::shared_ptr<shaderinputparameters::ShaderInputAndTypeStruct> parameter;
-        ShaderInputParameterType type;
-        if (property[this->key_valuetype] == key_int)
-        {
-            type = ShaderInputParameterType::kInt;
-            parameter = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>
-                (type, property[key_valuename], property[key_values][key_value].get<int>());
-        }
-        else if (property[this->key_valuetype] == key_float)
-        {
-            type = ShaderInputParameterType::kFloat;
-            parameter = std::make_shared
-                <shaderinputparameters::ShaderInputAndTypeStruct>(type, property[key_valuename], property[key_values][key_value].get<float>());
-        }
-        else if (property[this->key_valuetype] == key_vec3)
-        {
-            type = ShaderInputParameterType::kVec3;
-            utility::Vector3 vec3 = utility::Vector3(property[key_values]["x"].get<float>(), property[key_values]["y"].get<float>(), property[key_values]["z"].get<float>());
-            parameter = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>(type, property[key_valuename], vec3);
-        }
-        shader_input_parameters.emplace_back(parameter);
-
-
+        auto f = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kFloat, "c", 3.0f);
+        shader_input_parameters.emplace_back(f);
+        auto f2 = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kInt, "sample_int", 45);
+        shader_input_parameters.emplace_back(f2);
+        auto ve3_color = std::make_shared<shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kVec3, "color_vec3", utility::Vector3(1, 1, 1));
+        shader_input_parameters.emplace_back(ve3_color);
     }
 
-    // auto f = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kFloat, "c", 3.0f);
-    // shader_input_parameters.emplace_back(f);
-    // auto f2 = std::make_shared <shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kInt, "sample_int", 45);
-    // shader_input_parameters.emplace_back(f2);
-    // auto ve3_color = std::make_shared<shaderinputparameters::ShaderInputAndTypeStruct>(ShaderInputParameterType::kVec3, "color_vec3", utility::Vector3(1, 1, 1));
-    // shader_input_parameters.emplace_back(ve3_color);
     this->parameter[GETVALUENAME(shader_input_parameters)] = std::make_shared<assetparameters::Parameter>(shader_input_parameters, shaderinputs_assetoption);;
 }
 

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
@@ -90,7 +90,7 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
         shader_input_parameters.emplace_back(ve3_color);
     }
 
-    this->parameter[GETVALUENAME(shader_input_parameters)] = std::make_shared<assetparameters::Parameter>(shader_input_parameters, shaderinputs_assetoption);;
+    this->parameter[GETVALUENAME(shader_input_parameters)] = std::make_shared<assetparameters::Parameter>(&shader_input_parameters, shaderinputs_assetoption);;
 }
 
 

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.h
@@ -15,6 +15,16 @@ namespace editor::projectwindows::assets::elements::model::materials
 
         void Initialize();
 
+
+        const std::string key_value = "value";
+        const std::string key_values = "values";
+        const std::string key_valuename = "name";
+        const std::string key_valuetype = "type";
+        const std::string key_property = "property";
+        const std::string key_int = "int";
+        const std::string key_float = "float";
+        const std::string key_vec3 = "Vector3";
+
     public:
         Material(const std::filesystem::path& path, const std::shared_ptr<utility::youginuuid::YougineUuid>& uuid);
 

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.h
@@ -7,9 +7,9 @@ namespace editor::projectwindows::assets::elements::model::materials
     class Material : public Asset
     {
     private:
-        std::shared_ptr<shader::ShaderFileAsset> vert_asset_uuid;
+        std::shared_ptr<shader::ShaderFileAsset> vert_asset;
 
-        std::shared_ptr<shader::ShaderFileAsset> frag_asset_uuid;
+        std::shared_ptr<shader::ShaderFileAsset> frag_asset;
 
         std::vector<std::shared_ptr<shaderinputparameters::ShaderInputAndTypeStruct>> shader_input_parameters;
 

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/ShaderInputParameters/ShaderInputAndTypeStruct.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/ShaderInputParameters/ShaderInputAndTypeStruct.cpp
@@ -1,5 +1,8 @@
 ﻿#include "ShaderInputAndTypeStruct.h"
 
+#include <memory>
+#include <memory>
+
 editor::projectwindows::assets::elements::model::materials::shaderinputparameters::ShaderInputAndTypeStruct::
 ShaderInputAndTypeStruct(ShaderInputParameterType type, std::string name, float value) :type(type), name(name), float_value(value)
 {
@@ -47,4 +50,25 @@ utility::Vector3* editor::projectwindows::assets::elements::model::materials::sh
 ShaderInputAndTypeStruct::Get_vec3_value()
 {
     return vec3_value.get();
+}
+
+void editor::projectwindows::assets::elements::model::materials::shaderinputparameters::ShaderInputAndTypeStruct::
+SetValueType(ShaderInputParameterType type)
+{
+    this->type = type;
+}
+
+std::shared_ptr<editor::projectwindows::assets::elements::model::materials::shaderinputparameters::
+    ShaderInputAndTypeStruct> editor::projectwindows::assets::elements::model::materials::shaderinputparameters::
+    ShaderInputAndTypeStruct::GenerateDefaultInstance(ShaderInputParameterType type, std::string name)
+{
+    switch (type)
+    {
+    case ShaderInputParameterType::kInt:
+        return std::make_shared<ShaderInputAndTypeStruct>(ShaderInputParameterType::kInt, name, 1);
+    case ShaderInputParameterType::kFloat:
+        return std::make_shared<ShaderInputAndTypeStruct>(ShaderInputParameterType::kFloat, name, 1.0f);
+    case  ShaderInputParameterType::kVec3:
+        return std::make_shared<ShaderInputAndTypeStruct>(ShaderInputParameterType::kVec3, name, utility::Vector3(1, 1, 1));
+    }
 }

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/ShaderInputParameters/ShaderInputAndTypeStruct.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/ShaderInputParameters/ShaderInputAndTypeStruct.h
@@ -30,5 +30,8 @@ namespace editor::projectwindows::assets::elements::model::materials::shaderinpu
         float* Get_float_value();
         int* Get_int_value();
         utility::Vector3* Get_vec3_value();
+
+        void SetValueType(ShaderInputParameterType type);
+        static std::shared_ptr<ShaderInputAndTypeStruct> GenerateDefaultInstance(ShaderInputParameterType type, std::string name);
     };
 }

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/ShaderInputParameters/ShaderInputAndTypeStruct.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/ShaderInputParameters/ShaderInputAndTypeStruct.h
@@ -24,6 +24,7 @@ namespace editor::projectwindows::assets::elements::model::materials::shaderinpu
         ShaderInputAndTypeStruct(ShaderInputParameterType type, std::string name, int value);
         ShaderInputAndTypeStruct(ShaderInputParameterType type, std::string name, utility::Vector3 value);
 
+        void Export();
         ShaderInputParameterType GetValueType();
         std::string* GetName();
         float* Get_float_value();

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/TextAsset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/TextAsset.cpp
@@ -25,7 +25,7 @@ void editor::projectwindows::assets::elements::model::TextAsset::Export()
     json[GETVALUENAME(text)] = text;
     json[GETVALUENAME(uuid)] = uuid->convertstring();
 
-    auto exporter = std::make_shared<assetinfofileexporter::AssetInfoFileExporter>();
+    auto exporter = std::make_shared<assetinfos::AssetInfoFileExporter>();
     exporter->ExportAssetInfoFile(this->path, json);
 
 }

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/TextAsset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/TextAsset.cpp
@@ -7,7 +7,7 @@
 #include <tinygltf/json.hpp>
 
 
-#include "AssetInfoExporter/AssetInfoFileExporter.h"
+#include "AssetInfos/AssetInfoFileExporter.h"
 
 editor::projectwindows::assets::elements::model::TextAsset::TextAsset(std::filesystem::path path, std::shared_ptr<utility::youginuuid::YougineUuid> uuid) : Asset(path, uuid)
 {

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/shader/ShaderFileAsset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/shader/ShaderFileAsset.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <tinygltf/json.hpp>
 #include <filesystem>
+#include <memory>
 
 #include "../../../../../../Projects/Project.h"
 #include "../AssetInfos//AssetInfoFileExporter.h"
@@ -23,6 +24,8 @@ void editor::projectwindows::assets::elements::model::shader::ShaderFileAsset::I
         this->code += input + "\n";
     }
     std::cout << shaderfile_path << ": " << code << std::endl;
+    std::shared_ptr<inspectorwindows::assetviews::options::AssetViewOption> option = std::make_shared<inspectorwindows::assetviews::options::AssetViewOption>(false, true);
+    this->parameter[GETVALUENAME(code)] = std::make_shared<assetparameters::Parameter>(&code, option);
 }
 
 editor::projectwindows::assets::elements::model::shader::ShaderFileAsset::ShaderFileAsset(

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/shader/ShaderFileAsset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/shader/ShaderFileAsset.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <memory>
 #include <tinygltf/json.hpp>
+#include <filesystem>
 
 #include "../../../../../../Projects/Project.h"
 #include "../AssetInfos//AssetInfoFileExporter.h"
@@ -41,11 +42,20 @@ std::shared_ptr<editor::projectwindows::assets::elements::model::shader::ShaderF
 {
     if (vert_default == nullptr)
     {
-        auto id = std::make_shared<utility::youginuuid::YougineUuid>();
-        vert_default = std::make_shared<ShaderFileAsset>("./Resource/shader/test.vert", id);
-        projects::Project::GetInstance()->GetDataBase()->AddAsset(id, vert_default);
+        auto engineresouce_shaderinfo = projects::Project::GetInstance()->GetParameterFromEngineResourceJson("shader");
+        auto vertshaderfilePath = projects::Project::GetInstance()->GetEngineResouceFolderPath() / engineresouce_shaderinfo["default"]["vert"];
 
-        return vert_default;
+
+        // vert_default = std::make_shared<ShaderFileAsset>(vertshaderfilePath.string(), id);
+        std::shared_ptr<Asset> vertdefaultasset = projects::Project::GetInstance()->GetDataBase()->GetAssetFromFilePath(vertshaderfilePath);
+        std::shared_ptr<editor::projectwindows::assets::elements::model::shader::ShaderFileAsset> asset
+            = std::dynamic_pointer_cast<editor::projectwindows::assets::elements::model::shader::ShaderFileAsset>(vertdefaultasset);
+        if (asset == nullptr)
+        {
+            throw "vertexshaderのデフォルトアセットが見つからない。エンジンリソースの初期化が上手くいっていない可能性がある。";
+        }
+
+        vert_default = asset;
     }
     return vert_default;
 }
@@ -55,10 +65,20 @@ std::shared_ptr<editor::projectwindows::assets::elements::model::shader::ShaderF
 {
     if (frag_default == nullptr)
     {
-        auto id = std::make_shared<utility::youginuuid::YougineUuid>();
-        frag_default = std::make_shared<ShaderFileAsset>("./Resource/shader/test.frag", id);
-        projects::Project::GetInstance()->GetDataBase()->AddAsset(id, frag_default);
-        return frag_default;
+        auto engineresouce_shaderinfo = projects::Project::GetInstance()->GetParameterFromEngineResourceJson("shader");
+        auto vertshaderfilePath = projects::Project::GetInstance()->GetEngineResouceFolderPath() / engineresouce_shaderinfo["default"]["frag"];
+
+
+        // vert_default = std::make_shared<ShaderFileAsset>(vertshaderfilePath.string(), id);
+        std::shared_ptr<Asset> vertdefaultasset = projects::Project::GetInstance()->GetDataBase()->GetAssetFromFilePath(vertshaderfilePath);
+        std::shared_ptr<editor::projectwindows::assets::elements::model::shader::ShaderFileAsset> asset
+            = std::dynamic_pointer_cast<editor::projectwindows::assets::elements::model::shader::ShaderFileAsset>(vertdefaultasset);
+        if (asset == nullptr)
+        {
+            throw "fragmentshaderのデフォルトアセットが見つからない。エンジンリソースの初期化が上手くいっていない可能性がある。";
+        }
+
+        frag_default = asset;
     }
     return frag_default;
 }

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/shader/ShaderFileAsset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/shader/ShaderFileAsset.cpp
@@ -69,7 +69,7 @@ void editor::projectwindows::assets::elements::model::shader::ShaderFileAsset::E
     json[GETVALUENAME(uuid)] = uuid->convertstring();
     json[GETVALUENAME(shader_kind)] = shader_kind;
 
-    auto exporter = std::make_shared<assetinfofileexporter::AssetInfoFileExporter>();
+    auto exporter = std::make_shared<assetinfos::AssetInfoFileExporter>();
     exporter->ExportAssetInfoFile(this->path, json);
 }
 

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/shader/ShaderFileAsset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/shader/ShaderFileAsset.cpp
@@ -6,7 +6,7 @@
 #include <tinygltf/json.hpp>
 
 #include "../../../../../../Projects/Project.h"
-#include "../AssetInfoExporter/AssetInfoFileExporter.h"
+#include "../AssetInfos//AssetInfoFileExporter.h"
 
 void editor::projectwindows::assets::elements::model::shader::ShaderFileAsset::InitializeCode(
     std::filesystem::path shaderfile_path)

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/shader/ShaderFileAsset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/shader/ShaderFileAsset.cpp
@@ -75,9 +75,16 @@ void editor::projectwindows::assets::elements::model::shader::ShaderFileAsset::E
 
 void editor::projectwindows::assets::elements::model::shader::ShaderFileAsset::InitializeParameter()
 {
-    this->shader_kind = "fragment or vertex";
+    if (is_assetinfo_file_exist)
+    {
+        this->shader_kind = asset_info->GetParameter(GETVALUENAME(shader_kind));
+    }
+    else {
+        this->shader_kind = "fragment or vertex";
+    }
     auto assetoption = std::make_shared<inspectorwindows::assetviews::options::AssetViewOption>();
     this->parameter["shader_kind"] = std::make_shared<assetparameters::Parameter>(&shader_kind, assetoption);
+
 }
 
 std::string editor::projectwindows::assets::elements::model::shader::ShaderFileAsset::GetCode()

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
@@ -21,7 +21,7 @@ editor::projectwindows::ProjectWindow::ProjectWindow(editor::EditorWindowsManage
     yougine::Scene* scene)
     : EditorWindow(editor_windows_manager, editor::EditorWindowName::ProjectWindow)
 {
-    now_display_folderpath = projects::Project::GetInstance()->projectFolderPath;
+    now_display_folderpath = projects::Project::GetInstance()->GetProjectFolderPath_ByTypeString();
     auto lastchar = now_display_folderpath[now_display_folderpath.size() - 1];
     if (lastchar == '/') {
         now_display_folderpath.pop_back();

--- a/Engine/Core/src/yougine/Editor/PropertiesInputField.cpp
+++ b/Engine/Core/src/yougine/Editor/PropertiesInputField.cpp
@@ -60,7 +60,7 @@ namespace editor
                 }
                 else if (contentOfsharedptr == "class editor::projectwindows::assets::elements::model::Asset")
                 {
-                    std::cout << "asset!!" << std::endl;
+                    // std::cout << "asset!!" << std::endl;
                     auto asset = std::any_cast<std::shared_ptr<projectwindows::assets::elements::model::Asset>>(val);
                     auto func = std::any_cast<std::function<void(std::shared_ptr<editor::projectwindows::assets::elements::model::Asset>)>>(propertie[2]);
                     ImGui::Text(asset->GetAssetId()->convertstring().c_str());

--- a/Engine/Core/src/yougine/Editor/SceneWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/SceneWindow.cpp
@@ -6,7 +6,7 @@ editor::SceneWindow::SceneWindow(editor::EditorWindowsManager* editor_windows_ma
     yougine::Scene* scene) : EditorWindow(editor_windows_manager,
         editor::EditorWindowName::SceneWindow)
 {
-    this->renderManager = new yougine::managers::RenderManager(1920, 1080,scene->GetComponentList());
+    this->renderManager = new yougine::managers::RenderManager(1920, 1080, scene->GetComponentList());
 }
 
 void editor::SceneWindow::Draw()
@@ -16,6 +16,7 @@ void editor::SceneWindow::Draw()
     auto size = ImGui::GetContentRegionAvail();
     // auto size2 = ImGui::GetWindowSize();
     // renderManager->SetWindowSize(size);
+    renderManager->geterror("scenewindow error");
     renderManager->RenderScene();
     ImGui::Image((void*)(intptr_t)renderManager->GetColorBuffer(), ImVec2(size.x, size.y), ImVec2(0, 1), ImVec2(1, 0));
     ImGui::End();

--- a/Engine/Core/src/yougine/Projects/Project.cpp
+++ b/Engine/Core/src/yougine/Projects/Project.cpp
@@ -113,6 +113,21 @@ void projects::Project::Initialize(std::string project_file_path)
     //userfolderのパスを設定
     this->userfolder = this->projectFolderPath / c_userfolder;
 
+    //エンジン側が提供するリソースをプロジェクトに配置
+    this->engineresourcefolder = this->projectFolderPath / c_libraryfolder;
+    //engineresourcefolderというフォルダが無ければ作成
+    std::filesystem::create_directory(engineresourcefolder);
+    //配置
+    //test.vertをプロジェクトフォルダに配置
+    std::string resourcefolder = "./Resource/";
+    std::filesystem::copy(resourcefolder, this->engineresourcefolder, std::filesystem::copy_options::overwrite_existing | std::filesystem::copy_options::recursive);
+
+    //エンジン側が提供するリソース情報を管理するjsonファイルのパス
+    this->engineresource_InfofilePath = this->engineresourcefolder / this->c_libraryfolder_ResourceInfojsonFileName;
+    std::ifstream engineresourceinfofile(engineresource_InfofilePath, std::ios::in);
+    engineresourceinfofile >> engineresource_info_json_obj;
+
+
     std::vector<std::string> sceneFilePathVector;
     for (std::string a : projectData["SceneFileLocations"])
     {
@@ -165,9 +180,9 @@ void projects::Project::AssetInitialize()
             std::cerr << "asset is null" << " : " << path_string << std::endl;
         }
     }
-    auto nowfilepath = std::filesystem::current_path();
-    std::filesystem::path engine_Default_Path = "./Resource/Export/";
-    auto exportfile = std::filesystem::recursive_directory_iterator(engine_Default_Path);
+    // auto nowfilepath = std::filesystem::current_path();
+    // std::filesystem::path engine_Default_Path = "./Resource/Export/";
+    auto exportfile = std::filesystem::recursive_directory_iterator(this->engineresourcefolder);
 
     for (auto entry : exportfile)
     {
@@ -212,6 +227,16 @@ std::filesystem::path projects::Project::GetProjectFolderPath()
 std::string projects::Project::GetProjectFolderPath_ByTypeString()
 {
     return this->projectFolderPath.string();
+}
+
+nlohmann::basic_json<> projects::Project::GetParameterFromEngineResourceJson(std::string parameterName)
+{
+    return this->engineresource_info_json_obj[parameterName];
+}
+
+std::filesystem::path projects::Project::GetEngineResouceFolderPath()
+{
+    return this->projectFolderPath / this->c_libraryfolder;
 }
 
 projects::Project* projects::Project::instance;

--- a/Engine/Core/src/yougine/Projects/Project.cpp
+++ b/Engine/Core/src/yougine/Projects/Project.cpp
@@ -106,7 +106,13 @@ void projects::Project::Initialize(std::string project_file_path)
         std::cerr << "projectparse error at byte " << er.byte << std::endl;
     }
     reading.close();
-    this->projectFolderPath = projectData["Projectpath"];
+    //jsonからProjectpathを取得
+    std::string projectpathstr = projectData["Projectpath"];
+    this->projectFolderPath = projectpathstr;
+
+    //userfolderのパスを設定
+    this->userfolder = this->projectFolderPath / c_userfolder;
+
     std::vector<std::string> sceneFilePathVector;
     for (std::string a : projectData["SceneFileLocations"])
     {
@@ -133,7 +139,7 @@ void projects::Project::AssetInitialize()
     this->asset_database = std::make_shared<editor::projectwindows::assets::elements::model::assetdatabases::AssetDatabase>();
     projects::Project::GetInstance()->SetDataBase(asset_database);
 
-    auto projectpath = projectFolderPath;
+    auto projectpath = this->userfolder.string();
 
     auto file_and_folder_list = std::filesystem::recursive_directory_iterator(projectpath);
     //再帰的にプロジェクトパス以下のファイル全てをAssetクラスをさくせい　
@@ -193,5 +199,19 @@ void projects::Project::AssetInitialize()
     }
 }
 
+std::filesystem::path projects::Project::GetUserFolderPath()
+{
+    return this->userfolder;
+}
+
+std::filesystem::path projects::Project::GetProjectFolderPath()
+{
+    return this->projectFolderPath;
+}
+
+std::string projects::Project::GetProjectFolderPath_ByTypeString()
+{
+    return this->projectFolderPath.string();
+}
 
 projects::Project* projects::Project::instance;

--- a/Engine/Core/src/yougine/Projects/Project.h
+++ b/Engine/Core/src/yougine/Projects/Project.h
@@ -10,7 +10,7 @@ namespace projects
     {
     private:
 
-        const std::string c_userfolder = "userFolder";
+
         static Project* instance;
         std::shared_ptr<editor::projectwindows::assets::elements::model::assetdatabases::AssetDatabase> asset_database;
         std::shared_ptr<editor::projectwindows::assets::elements::model::Asset> GenerateAssetFromFile(std::filesystem::path path, std::shared_ptr<utility::youginuuid::YougineUuid> uuid);
@@ -19,12 +19,30 @@ namespace projects
          * \brief プロジェクトパス/userFolder　ユーザがスクリプトやアセットを置く場所
          */
         std::filesystem::path userfolder;
+
+        /**
+         * \brief プロジェクトフォルダ直下にある
+         */
+        std::filesystem::path engineresourcefolder;
+
+        std::filesystem::path engineresource_InfofilePath;
+
+        /**
+         * \brief エンジンのリソースについての情報をjsonをパースしたもの。
+         */
+        nlohmann::json engineresource_info_json_obj;
+
         //プロジェクトフォルダのパスを格納（main.cppで指定しているが、実行時引数とかで貰うようにするのがよさそう）
         std::filesystem::path projectFolderPath;
 
+
+
+
     public:
 
-
+        const std::string c_userfolder = "userFolder";
+        const std::string c_libraryfolder = "libFolder";
+        const std::string c_libraryfolder_ResourceInfojsonFileName = "ResourceInfo.json";
         static Project* GetInstance();
         void Initialize(std::string project_file_path);
         void SetDataBase(std::shared_ptr<editor::projectwindows::assets::elements::model::assetdatabases::AssetDatabase> asset_database);
@@ -34,5 +52,14 @@ namespace projects
         std::filesystem::path GetProjectFolderPath();
 
         std::string GetProjectFolderPath_ByTypeString();
+
+        /**
+         * \brief エンジン側が提供するリソースの情報を取得できる
+         * \param parameterName
+         * \return
+         */
+        nlohmann::basic_json<> GetParameterFromEngineResourceJson(std::string parameterName);
+
+        std::filesystem::path GetEngineResouceFolderPath();
     };
 }

--- a/Engine/Core/src/yougine/Projects/Project.h
+++ b/Engine/Core/src/yougine/Projects/Project.h
@@ -9,17 +9,30 @@ namespace projects
     class Project
     {
     private:
+
+        const std::string c_userfolder = "userFolder";
         static Project* instance;
         std::shared_ptr<editor::projectwindows::assets::elements::model::assetdatabases::AssetDatabase> asset_database;
         std::shared_ptr<editor::projectwindows::assets::elements::model::Asset> GenerateAssetFromFile(std::filesystem::path path, std::shared_ptr<utility::youginuuid::YougineUuid> uuid);
-    public:
+
+        /**
+         * \brief プロジェクトパス/userFolder　ユーザがスクリプトやアセットを置く場所
+         */
+        std::filesystem::path userfolder;
         //プロジェクトフォルダのパスを格納（main.cppで指定しているが、実行時引数とかで貰うようにするのがよさそう）
-        std::string projectFolderPath;
+        std::filesystem::path projectFolderPath;
+
+    public:
+
 
         static Project* GetInstance();
         void Initialize(std::string project_file_path);
         void SetDataBase(std::shared_ptr<editor::projectwindows::assets::elements::model::assetdatabases::AssetDatabase> asset_database);
         std::shared_ptr < editor::projectwindows::assets::elements::model::assetdatabases::AssetDatabase>  GetDataBase();
         void AssetInitialize();
+        std::filesystem::path GetUserFolderPath();
+        std::filesystem::path GetProjectFolderPath();
+
+        std::string GetProjectFolderPath_ByTypeString();
     };
 }

--- a/Engine/Core/src/yougine/componentclassnames/ComponentClassNames.cpp
+++ b/Engine/Core/src/yougine/componentclassnames/ComponentClassNames.cpp
@@ -48,7 +48,7 @@ std::vector<std::string> ComponentClassNames::ComponentClassNames::GetComponentC
 
 void ComponentClassNames::ComponentClassNames::AddUserScriptNames()
 {
-    auto componentnameFile = projects::Project::GetInstance()->projectFolderPath + "/usercomponentnames.json";
+    auto componentnameFile = projects::Project::GetInstance()->GetUserFolderPath() / "usercomponentnames.json";
 
     std::ifstream reading(componentnameFile, std::ios::in);
     using json = nlohmann::ordered_json;

--- a/Engine/Core/src/yougine/components/RenderComponent.h
+++ b/Engine/Core/src/yougine/components/RenderComponent.h
@@ -15,6 +15,22 @@ namespace yougine::components
     {
         GLfloat position[3];
     };
+
+    struct VBOList
+    {
+        GLuint vertexBuffer;
+        GLuint elementBuffer;
+        GLuint normalBuffer;
+        void Release()
+        {
+            GLuint vboIDs[] = { vertexBuffer, elementBuffer, normalBuffer };
+            glDeleteBuffers(3, vboIDs);
+            vertexBuffer = -1;
+            elementBuffer = -1;
+            normalBuffer = -1;
+
+        }
+    };
     class RenderComponent : public components::Component
     {
         //マテリアル（シェーダー、シェーダに渡す値）、メッシュ。
@@ -52,10 +68,13 @@ namespace yougine::components
         GLuint program;
 
         GLuint vao;
+        VBOList vbolist;
 
         std::vector<ShaderVector4> vertex_vector;
 
         std::vector<GLuint> index_vector;
+        void ShaderCompile();
+        void InitializeMesh();
 
     };
 }

--- a/Engine/Core/src/yougine/managers/RenderManager.cpp
+++ b/Engine/Core/src/yougine/managers/RenderManager.cpp
@@ -31,7 +31,6 @@ namespace yougine::managers
     RenderManager::RenderManager(int width, int height, ComponentList* component_list)
     {
         this->component_list = component_list;
-        GLenum err;
         this->width = width;
         this->height = height;
         //カラーバッファ
@@ -63,18 +62,16 @@ namespace yougine::managers
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         this->frameBuffer = frameBuffer;
 
-        while ((err = glGetError()) != GL_NO_ERROR)
-        {
-            std::cout << err << " というエラーがある in constructer" << std::endl;
-        }
+        geterror("in rendermanager constructer");
     }
 
     RenderManager::RenderManager(int width, int height, GLint input_framebuffer, ComponentList* component_list)
     {
         this->component_list = component_list;
-        GLenum err;
         this->width = width;
         this->height = height;
+        geterror("in rendermanager constructer");
+
         //カラーバッファ
         GLuint colorBuffer;
         glGenTextures(1, &colorBuffer);
@@ -85,6 +82,7 @@ namespace yougine::managers
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         this->colorBuffer = colorBuffer;
+        geterror("in rendermanager constructer");
 
         //デプスバッファ
         GLuint depthBuffer;
@@ -92,6 +90,7 @@ namespace yougine::managers
         glBindRenderbuffer(GL_RENDERBUFFER, depthBuffer);
         glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, width, height);
         this->depthBuffer = depthBuffer;
+        geterror("in rendermanager constructer");
 
         //フレームバッファ
         GLuint frameBuffer = input_framebuffer;
@@ -104,10 +103,8 @@ namespace yougine::managers
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         this->frameBuffer = frameBuffer;
 
-        while ((err = glGetError()) != GL_NO_ERROR)
-        {
-            std::cout << err << " というエラーがある in constructer" << std::endl;
-        }
+        geterror("in rendermanager constructer");
+
     }
 
     /**
@@ -230,7 +227,6 @@ namespace yougine::managers
         glUniformMatrix4fv(vShader_mvp_pointer, 1, GL_FALSE, &MVP[0][0]);
 
         geterror("RenderOneGameObject");
-        RenderManager::getcurrentbindProgram();
 
         auto shaderinputs = render_component->GetMaterial()->GetShaderInputs();
         for (auto shader_input_and_type_struct : shaderinputs)

--- a/Engine/Core/src/yougine/managers/RenderManager.cpp
+++ b/Engine/Core/src/yougine/managers/RenderManager.cpp
@@ -31,7 +31,6 @@ namespace yougine::managers
     RenderManager::RenderManager(int width, int height, ComponentList* component_list)
     {
         this->component_list = component_list;
-        this->renderComponent = new components::RenderComponent();
         GLenum err;
         this->width = width;
         this->height = height;
@@ -73,7 +72,6 @@ namespace yougine::managers
     RenderManager::RenderManager(int width, int height, GLint input_framebuffer, ComponentList* component_list)
     {
         this->component_list = component_list;
-        this->renderComponent = new components::RenderComponent();
         GLenum err;
         this->width = width;
         this->height = height;
@@ -124,6 +122,8 @@ namespace yougine::managers
      */
     void RenderManager::RenderScene()
     {
+        geterror("RenderScene");
+
         auto camera = components::camera::CameraComponent::GetMainCamera();
 
         glBindFramebuffer(GL_FRAMEBUFFER, this->frameBuffer);
@@ -133,6 +133,8 @@ namespace yougine::managers
         glClearBufferfv(GL_DEPTH, 0, &depth);
         glEnable(GL_DEPTH_TEST);
         // glEnable(GL_CULL_FACE);
+        geterror("RenderScene");
+
         int i = 0;
         //オブジェクトそれぞれ描画
         auto render_component_list = component_list->GetReferObjectList(components::ComponentName::kRender);
@@ -173,13 +175,12 @@ namespace yougine::managers
     void SetVec3Uniform(GLint program, const char* name, utility::Vector3 value)
     {
         GLuint loc = glGetUniformLocation(program, name);
+
+        RenderManager::geterror("glGetUniformLocation");
+
         // Send the float data
         glUniform3f(loc, value.x, value.y, value.z);
-        GLuint err;
-        while ((err = glGetError()) != GL_NO_ERROR)
-        {
-            std::cout << err << " というエラーがある in setfloatuniform" << std::endl;
-        }
+        RenderManager::geterror("glUniform3f");
     }
     /**
      * \brief ゲームオブジェクトを描画する
@@ -187,8 +188,23 @@ namespace yougine::managers
      */
     void RenderManager::RenderOneGameObject(components::RenderComponent* render_component, std::shared_ptr<components::camera::CameraComponent> camera)
     {
-        glUseProgram(this->renderComponent->GetProgram());
-        glBindVertexArray(this->renderComponent->GetVao());
+        geterror("RenderOneGameObject beforegetprogram");
+
+        auto program = render_component->GetProgram();
+        // GLint linkStatus;
+        // glGetProgramiv(program, GL_LINK_STATUS, &linkStatus);
+        // if (linkStatus == GL_FALSE) {
+        //     // リンク失敗の処理
+        //     char infoLog[512];
+        //     glGetProgramInfoLog(program, 512, NULL, infoLog);
+        //     std::cerr << "ERROR::SHADER::PROGRAM::LINKING_FAILED\n" << infoLog << std::endl;
+        // }
+
+        glUseProgram(render_component->GetProgram());
+        geterror("RenderOneGameObject GetProgram");
+
+        glBindVertexArray(render_component->GetVao());
+        geterror("RenderOneGameObject GetVao()");
         glm::mat4 Projection = glm::perspective(glm::radians(45.0f), 4.0f / 3.0f, 0.1f, 400.0f);
 
         auto cameraposition = camera->GetTransform()->GetPosition();
@@ -210,18 +226,17 @@ namespace yougine::managers
         //Model行列を定義
         glm::mat4 Model = glm::translate(glm::vec3(position.x, position.y, position.z)) * rotation->ConvertToGlmMat4();
         glm::mat4 MVP = Projection * View * Model;
-        auto vShader_mvp_pointer = glGetUniformLocation(this->renderComponent->GetProgram(), "mvp");
+        auto vShader_mvp_pointer = glGetUniformLocation(render_component->GetProgram(), "mvp");
         glUniformMatrix4fv(vShader_mvp_pointer, 1, GL_FALSE, &MVP[0][0]);
-        GLenum err;
-        while ((err = glGetError()) != GL_NO_ERROR)
-        {
-            std::cout << err << " というエラーがある in rendergameobject" << std::endl;
-        }
+
+        geterror("RenderOneGameObject");
+        RenderManager::getcurrentbindProgram();
+
         auto shaderinputs = render_component->GetMaterial()->GetShaderInputs();
         for (auto shader_input_and_type_struct : shaderinputs)
         {
             if (shader_input_and_type_struct->GetValueType() == editor::projectwindows::assets::elements::model::materials::ShaderInputParameterType::kFloat) {
-                SetFloatUniform(renderComponent->GetProgram(), shader_input_and_type_struct->GetName()->c_str(), *shader_input_and_type_struct->Get_float_value());
+                SetFloatUniform(render_component->GetProgram(), shader_input_and_type_struct->GetName()->c_str(), *shader_input_and_type_struct->Get_float_value());
             }
             else if (shader_input_and_type_struct->GetValueType() == editor::projectwindows::assets::elements::model::materials::ShaderInputParameterType::kVec3)
             {
@@ -243,6 +258,7 @@ namespace yougine::managers
 
     GLuint RenderManager::ShaderInit(std::string vs_shader_source, std::string fs_shader_source)
     {
+        geterror("ShaderInit");
         const auto program = glCreateProgram();
 
         //シェーダオブジェクト生成
@@ -253,13 +269,15 @@ namespace yougine::managers
         const char* vsShaderSource_char = vs_shader_source.c_str();
         std::cout << "vertex \n" << vs_shader_source << std::endl;
         glShaderSource(vsShader, 1, &vsShaderSource_char, nullptr);
+
         const char* fsShaderSource_char = fs_shader_source.c_str();
+        std::cout << "vertex \n" << fs_shader_source << std::endl;
         glShaderSource(fsShader, 1, &fsShaderSource_char, nullptr);
 
         //コンパイル
         glCompileShader(vsShader);
         glCompileShader(fsShader);
-
+        geterror("ShaderInit");
         //エラー
         PrintShaderInfoLog(vsShader, "vertex shader");
         PrintShaderInfoLog(fsShader, "fragment shader");
@@ -271,6 +289,8 @@ namespace yougine::managers
         glDeleteShader(fsShader);
 
         glLinkProgram(program);
+
+        geterror("ShaderInit");
 
         return program;
     }
@@ -348,4 +368,27 @@ namespace yougine::managers
 
         return content;
     }
+
+    void RenderManager::geterror(std::string adderErrortext)
+    {
+        GLenum err;
+        while ((err = glGetError()) != GL_NO_ERROR)
+        {
+            std::cout << err << " というエラーがある " << adderErrortext << std::endl;
+        }
+    }
+
+    void RenderManager::getcurrentbindProgram()
+    {
+        GLint currentProgram = 0;
+        glGetIntegerv(GL_CURRENT_PROGRAM, &currentProgram);
+
+        if (currentProgram != 0) {
+            printf("Currently bound shader program ID: %d\n", currentProgram);
+        }
+        else {
+            printf("No shader program is currently bound.\n");
+        }
+    }
 }
+

--- a/Engine/Core/src/yougine/managers/RenderManager.h
+++ b/Engine/Core/src/yougine/managers/RenderManager.h
@@ -35,7 +35,8 @@ namespace yougine::managers
         GLuint GetColorBuffer();
 
         void SetWindowSize(ImVec2 vec2);
-
+        static void geterror(std::string adderErrortext);
+        static void getcurrentbindProgram();
     private:
         ComponentList* component_list;
 
@@ -43,7 +44,6 @@ namespace yougine::managers
 
         GLuint frameBuffer;
 
-        components::RenderComponent* renderComponent;
 
         GLuint colorBuffer;
 

--- a/Engine/Core/src/yougine/utilitys/view/parameters/ShaderInputParameterView.cpp
+++ b/Engine/Core/src/yougine/utilitys/view/parameters/ShaderInputParameterView.cpp
@@ -8,6 +8,7 @@
 
 void utility::view::parameters::ShaderInputParameterView::Draw()
 {
+    ImGui::Separator();
     ImGui::Text("shader input parameterview");
     int index = 0;
     for (auto element : *vec_shaderinput)
@@ -83,6 +84,7 @@ void utility::view::parameters::ShaderInputParameterView::Draw()
     ImGui::PushID(index++);
     ImGui::PushItemWidth(80);
     ImGui::Text("new input paramter ");
+    ImGui::SameLine();
     if (ImGui::BeginCombo(this->label.c_str(), this->type2text[new_value->GetValueType()].c_str()))
     {
         for (auto pair : type2text)
@@ -104,7 +106,7 @@ void utility::view::parameters::ShaderInputParameterView::Draw()
         }
         ImGui::EndCombo();
     }
-    // ImGui::SameLine();
+    ImGui::SameLine();
 
     // //名前入力
     ImGui::InputText("name", new_value->GetName());
@@ -152,6 +154,7 @@ void utility::view::parameters::ShaderInputParameterView::Draw()
     ImGui::PopID();
 
     ImGui::NewLine();
+    ImGui::Separator();
 }
 
 utility::view::parameters::ShaderInputParameterView::ShaderInputParameterView(

--- a/Engine/Core/src/yougine/utilitys/view/parameters/ShaderInputParameterView.cpp
+++ b/Engine/Core/src/yougine/utilitys/view/parameters/ShaderInputParameterView.cpp
@@ -1,6 +1,7 @@
 ﻿#include "ShaderInputParameterView.h"
 
 #include <iostream>
+#include <memory>
 
 #include "../../../Editor/ShaderGraph/ShaderType.h"
 #include "imgui/stblib/imgui_stdlib.h"
@@ -9,7 +10,7 @@ void utility::view::parameters::ShaderInputParameterView::Draw()
 {
     ImGui::Text("shader input parameterview");
     int index = 0;
-    for (auto element : this->vec_shaderinput)
+    for (auto element : *vec_shaderinput)
     {
         ImGui::PushID(index++);
         ImGui::PushItemWidth(80);
@@ -78,16 +79,91 @@ void utility::view::parameters::ShaderInputParameterView::Draw()
         ImGui::PopItemWidth();
         ImGui::PopID();
     }
+    //追加ボタン
+    ImGui::PushID(index++);
+    ImGui::PushItemWidth(80);
+    ImGui::Text("new input paramter ");
+    if (ImGui::BeginCombo(this->label.c_str(), this->type2text[new_value->GetValueType()].c_str()))
+    {
+        for (auto pair : type2text)
+        {
+            auto target_type = pair.first;
+            const bool is_selected = (target_type == new_value->GetValueType());
+            auto typetext = type2text[target_type];
+            //選んだ時
+            if (ImGui::Selectable(typetext.c_str(), is_selected))
+            {
+                new_value = shaderinputparameters::ShaderInputAndTypeStruct::GenerateDefaultInstance(target_type, "newvalue");
+                std::cout << "select" << std::endl;
+
+            }
+            if (is_selected)
+            {
+                ImGui::SetItemDefaultFocus();
+            }
+        }
+        ImGui::EndCombo();
+    }
+    // ImGui::SameLine();
+
+    // //名前入力
+    ImGui::InputText("name", new_value->GetName());
+
+
+    switch (new_value->GetValueType())
+    {
+    case materials::ShaderInputParameterType::kFloat:
+        ImGui::SameLine();
+        if (ImGui::InputFloat("value", new_value->Get_float_value()))
+        {
+        }
+        break;
+    case materials::ShaderInputParameterType::kInt:
+        ImGui::SameLine();
+        if (ImGui::InputInt("value", new_value->Get_int_value()))
+        {
+        }
+        break;
+    case materials::ShaderInputParameterType::kVec3: {
+        ImGui::SameLine();
+        auto value = new_value->Get_vec3_value();
+        float tmpvalue[3] = { value->x,value->y,value->z };
+        if (ImGui::ColorEdit3("value", tmpvalue))
+        {
+            value->x = tmpvalue[0];
+            value->y = tmpvalue[1];
+            value->z = tmpvalue[2];
+        }
+        break;
+    }
+    default:
+        ImGui::SameLine();
+        ImGui::Text("Type not supported");
+        break;
+    }
+
+    if (ImGui::Button("shader input parameter add"))
+    {
+        //newvalueを追加
+        this->vec_shaderinput->push_back(this->new_value);
+        this->new_value = shaderinputparameters::ShaderInputAndTypeStruct::GenerateDefaultInstance(materials::ShaderInputParameterType::kInt, "valuename");
+    }
+    ImGui::PopItemWidth();
+    ImGui::PopID();
+
+    ImGui::NewLine();
 }
 
 utility::view::parameters::ShaderInputParameterView::ShaderInputParameterView(
-    std::vector<std::shared_ptr<shaderinputparameters::ShaderInputAndTypeStruct>> vec_shaderinput)
+    std::vector<std::shared_ptr<shaderinputparameters::ShaderInputAndTypeStruct>>* vec_shaderinput)
 {
     // this->type_list = { "float", "vec3" };
-    label = "type";
+    // label = "type";
     this->vec_shaderinput = vec_shaderinput;
     this->type2text = {
         {materials::ShaderInputParameterType::kFloat, "float"},
-        {materials::ShaderInputParameterType::kInt, "int"}
+        {materials::ShaderInputParameterType::kInt, "int"},
+        {materials::ShaderInputParameterType::kVec3, "vec3"}
     };
+    this->new_value = shaderinputparameters::ShaderInputAndTypeStruct::GenerateDefaultInstance(materials::ShaderInputParameterType::kInt, "valuename");
 }

--- a/Engine/Core/src/yougine/utilitys/view/parameters/ShaderInputParameterView.h
+++ b/Engine/Core/src/yougine/utilitys/view/parameters/ShaderInputParameterView.h
@@ -11,10 +11,11 @@ namespace utility::view::parameters
     namespace materials = editor::projectwindows::assets::elements::model::materials;
     namespace shaderinputparameters = materials::shaderinputparameters;
 
+
     class ShaderInputParameterView : public ParameterView
     {
         // std::vector<std::string> type_list;
-        std::string label;
+        const std::string label = "type";;
 
         std::string name;
 
@@ -22,12 +23,16 @@ namespace utility::view::parameters
 
         std::map<materials::ShaderInputParameterType, std::string> type2text;
 
-        std::vector<std::shared_ptr<shaderinputparameters::ShaderInputAndTypeStruct>> vec_shaderinput;
+        std::vector<std::shared_ptr<shaderinputparameters::ShaderInputAndTypeStruct>>* vec_shaderinput;
+
+        std::shared_ptr<shaderinputparameters::ShaderInputAndTypeStruct> new_value;
+
+        // std::shared_ptr<>
 
     public:
         void Draw() override;
 
         ShaderInputParameterView(
-            std::vector<std::shared_ptr<shaderinputparameters::ShaderInputAndTypeStruct>> vec_shaderinput);
+            std::vector<std::shared_ptr<shaderinputparameters::ShaderInputAndTypeStruct>>* vec_shaderinput);
     };
 }

--- a/Engine/CoreExeBuildProject/Resource/ResourceInfo.json
+++ b/Engine/CoreExeBuildProject/Resource/ResourceInfo.json
@@ -1,0 +1,8 @@
+{
+    "shader": {
+        "default": {
+            "vert": "shader/test.vert",
+            "frag": "shader/test.frag"
+        }
+    }
+}

--- a/Engine/CoreExeBuildProject/src/main.cpp
+++ b/Engine/CoreExeBuildProject/src/main.cpp
@@ -94,13 +94,13 @@ int main()
     //シーンファイルのエクスポート（本来はeditor上の操作によりエクスポートしたい。
     //なんならビルド先にできるのおかしい。ビルド時にファイルコピーがされるべき）
     auto sceneexporter = new yougine::SceneFiles::SceneFileExporter();
-    auto projectpath = projects::Project::GetInstance()->projectFolderPath;
+    auto projectpath = projects::Project::GetInstance()->GetProjectFolderPath_ByTypeString();
     auto buildfolder = projectpath + "build\\";
     if (_mkdir(buildfolder.c_str())) {
         std::cout << "buildフォルダ作成" << std::endl;
     }
     //シーンファイルのパス
-    std::string scenefilepath = project->projectFolderPath + "\\build\\scene.json";
+    std::string scenefilepath = project->GetProjectFolderPath_ByTypeString() + "\\build\\scene.json";
     yougine::Scene* scene;
     FILE* fp;
     errno_t error;

--- a/Engine/GameBuildProject/Resource/Project.json
+++ b/Engine/GameBuildProject/Resource/Project.json
@@ -1,0 +1,3 @@
+{
+  "Projectpath": "D:/Yougin/"
+}

--- a/Engine/GameBuildProject/Resource/shader/test.frag
+++ b/Engine/GameBuildProject/Resource/shader/test.frag
@@ -2,6 +2,8 @@
 out vec4 fragment;
 in vec3 vNormal;
 uniform float c;
+uniform vec3 color_vec3;
 void main() {
-fragment = vec4(vNormal, 1.0); 
+float diffuse=dot(vNormal,vec3(1,1,1));
+fragment = vec4(color_vec3*diffuse, 1.0); 
 }

--- a/Engine/GameBuildProject/src/main.cpp
+++ b/Engine/GameBuildProject/src/main.cpp
@@ -34,8 +34,10 @@ static void glfw_error_callback(int error, const char* description)
 int main()
 {
     auto project = projects::Project::GetInstance();
-    project->projectFolderPath = "D:\\Yougin\\";//プロジェクトパスを直書きしてるのでよろしくない
-    project->AssetInitialize();
+    // project->projectFolderPath = "D:\\Yougin\\";//プロジェクトパスを直書きしてるのでよろしくない
+    // project->AssetInitialize();
+    project->Initialize("./Resource/Project.json");
+
     glfwSetErrorCallback(glfw_error_callback);
 
     if (glfwInit() == GLFW_FALSE)

--- a/Engine/GameBuildProject/src/main.cpp
+++ b/Engine/GameBuildProject/src/main.cpp
@@ -116,12 +116,16 @@ int main()
 
     //render
     auto rendermanager = yougine::managers::RenderManager(1920, 1080, windowframebuffer, scene->GetComponentList());
+    scene->InitializeAllGameObjcts();
     while (glfwWindowShouldClose(window) == GL_FALSE)
     {
-        input_manager->UpdateInput();
+        // input_manager->UpdateInput();
         rendermanager.RenderScene();
         glfwSwapBuffers(window);
         glfwPollEvents();
+
+        game_manager->Update();
+        scene->Update();
         /*
         if (input_manager->IsPushKey(yougine::KeyBind::RightClick))
         {

--- a/Engine/GameBuildProject/src/main.cpp
+++ b/Engine/GameBuildProject/src/main.cpp
@@ -77,7 +77,7 @@ int main()
 
     // yougine::Scene* scene = new yougine::Scene("Scene1");
     auto sceneloader = yougine::SceneFiles::SceneLoader();
-    sceneloader.UpdateJsonObj(project->projectFolderPath + "\\build\\scene.json");
+    sceneloader.UpdateJsonObj(project->GetProjectFolderPath_ByTypeString() + "\\build\\scene.json");
     sceneloader.CreateScene();
     yougine::Scene* scene = sceneloader.jb_scene;
     // int gVCBHeig3ht = 300;


### PR DESCRIPTION
マテリアルアセットのシェーダへの入力をエディタから追加できるようにした。
![image](https://github.com/heller77/Yougine/assets/60052348/89af018c-40ae-47c4-8259-26c8f4815428)

マテリアルをレンダーコンポーネントにエディタから切り替えると、シェーダがコンパイルされて適用されるようにした。
- fixed #88 
- マテリアルについては修正 #93 

アセットインフォファイルを管理するクラス（AssetInfoFileクラス）を作ったので、#93 についてはマテリアル以外のアセットも今後適宜実装。