### PR TITLE
IUpdatableを一個だけ登録できるように

### DIFF
--- a/Engine/Core/src/yougine/Projects/Project.cpp
+++ b/Engine/Core/src/yougine/Projects/Project.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <fstream>
 
+#include "../BuildScript/UserScriptCompiler.h"
 #include "../Editor/ProjectWindows/Assets/element/Model/TextAsset.h"
 #include "../Editor/ProjectWindows/Assets/element/Model/CustomScripts/CustomScriptAsset.h"
 #include "../Editor/ProjectWindows/Assets/element/Model/Material/Material.h"
@@ -153,6 +154,10 @@ void projects::Project::Initialize(std::string project_file_path)
     {
         std::cout << a << std::endl;
     }
+
+    //ユーザスクリプトコンパイル
+    builders::UserScriptCompiler::Compile();
+
     this->AssetInitialize();
 }
 

--- a/Engine/UserEngineCommon/include/UserShare/Scene.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/Scene.cpp
@@ -89,9 +89,9 @@ namespace yougine
         }
     }
 
-    void Scene::AddRegisterUpdate(std::function<void()> method)
+    void Scene::RegisterOnlyUpdate(components::userscriptcomponents::IUpdatable* i_updatable)
     {
-        this->user_script_component_entry_point_manager->AddUpdate(method);
+        this->user_script_component_entry_point_manager->SetUpdate(i_updatable);
     }
 
 

--- a/Engine/UserEngineCommon/include/UserShare/Scene.h
+++ b/Engine/UserEngineCommon/include/UserShare/Scene.h
@@ -4,6 +4,7 @@
 #include <list>
 
 #include "InputManager.h"
+#include "components/userscriptcomponents/IUpdatable.h"
 #include "managers/UserScriptComponentEntryPointManager.h"
 #include "UserShare/Layer.h"
 #include "UserShare/MacroDifHeader.h"
@@ -36,7 +37,7 @@ namespace yougine
 
         std::shared_ptr<InputManager> GetInputManager();
 
-        void AddRegisterUpdate(std::function<void()> method);
+        void RegisterOnlyUpdate(components::userscriptcomponents::IUpdatable* i_updatable);
         /*
          *ユーザが呼ばない!!
          *

--- a/Engine/UserEngineCommon/include/UserShare/managers/UserScriptComponentEntryPointManager.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/managers/UserScriptComponentEntryPointManager.cpp
@@ -1,19 +1,25 @@
 ﻿#include "UserScriptComponentEntryPointManager.h"
 
+#include <iostream>
+
 yougine::managers::UserScriptComponentEntryPointManager::UserScriptComponentEntryPointManager()
 {
-    this->updateMethods = {};
+    this->update_entrypoint = nullptr;
 }
 
-void yougine::managers::UserScriptComponentEntryPointManager::AddUpdate(std::function<void()> method)
+void yougine::managers::UserScriptComponentEntryPointManager::SetUpdate(components::userscriptcomponents::IUpdatable* i_updatable)
 {
-    this->updateMethods.push_back(method);
+    if (update_entrypoint != nullptr)
+    {
+        std::cout << "update に既に登録されています。上書きします。" << std::endl;
+    }
+    update_entrypoint = i_updatable;
 }
 
 void yougine::managers::UserScriptComponentEntryPointManager::Update()
 {
-    for (auto callback : this->updateMethods)
+    if (update_entrypoint != nullptr)
     {
-        callback();
+        this->update_entrypoint->Update();
     }
 }

--- a/Engine/UserEngineCommon/include/UserShare/managers/UserScriptComponentEntryPointManager.h
+++ b/Engine/UserEngineCommon/include/UserShare/managers/UserScriptComponentEntryPointManager.h
@@ -1,11 +1,14 @@
 ﻿#pragma once
 #include <functional>
+
+#include "UserShare/components/userscriptcomponents/IUpdatable.h"
+
 namespace yougine::managers
 {
     class UserScriptComponentEntryPointManager
     {
     private:
-        std::vector<std::function<void(void)>> updateMethods;
+        components::userscriptcomponents::IUpdatable* update_entrypoint;
     public:
         UserScriptComponentEntryPointManager();
 
@@ -13,7 +16,7 @@ namespace yougine::managers
          * \brief update関数を追加する
          * \param method
          */
-        void AddUpdate(std::function<void(void)> method);
+        void SetUpdate(components::userscriptcomponents::IUpdatable* i_updatable);
 
         /**
          * \brief updateを実行する（ユーザは呼ばないで！）


### PR DESCRIPTION
- fix #92 

毎フレーム呼ばれる関数を複数追加できる仕様だったのを、IUpdatableを一個だけ登録できるようにした。
