### PR TITLE
ヒエラルキーウィンドー上でオブジェクトを削除できるように

### DIFF
--- a/Engine/Core/src/yougine/Editor/HierarchyWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/HierarchyWindow.cpp
@@ -78,12 +78,37 @@ namespace editor
                 if (ImGui::IsWindowHovered())
                 {
                     selection_info->SetSelectionInfo(nullptr, true);
+
                 }
+            }
+            //右クリックしたら
+            if (ImGui::IsItemClicked(1))
+            {
+                ImGui::OpenPopup("contextmenu");
+            }
+            if (ImGui::BeginPopup("contextmenu"))
+            {
+                ImGui::Text("_contextmenu_");
+                auto nowselectGameObjcet = selection_info->GetSelectObject();
+                if (nowselectGameObjcet != nullptr) {
+                    std::string display_removeobject = "remove " + nowselectGameObjcet->GetName();
+                    if (ImGui::Selectable(display_removeobject.c_str()))
+                    {
+                        scene->RemoveGameObjcect(nowselectGameObjcet);
+                        //選択しているオブジェクトはなくなるので、nullをセット
+                        selection_info->SetSelectionInfo(nullptr, true);
+                        game_object = nullptr;
+                    }
+                }
+                ImGui::EndPopup();
             }
 
             if (is_open_tree)
             {
-                RecursiveTree(game_object->GetChildObjects());
+                if (game_object != nullptr) {
+                    auto child = game_object->GetChildObjects();
+                    RecursiveTree(child);
+                }
                 ImGui::TreePop();
             }
         }

--- a/Engine/Core/src/yougine/components/RenderComponent.cpp
+++ b/Engine/Core/src/yougine/components/RenderComponent.cpp
@@ -24,7 +24,7 @@ namespace yougine::components
 
         std::function<void(std::shared_ptr<assetnamespace::Asset>)> function =
             managers::ComponentExportParameterManager::Generate_AssetTypeField_Switch_Function(
-                std::shared_ptr<components::Component>(this), &material, GETVALUENAME(material));
+                this, &material, GETVALUENAME(material));
 
         std::function<void(std::shared_ptr<assetnamespace::Asset>)> parentfunction = [=](std::shared_ptr<assetnamespace::Asset> input) {
             std::cout << "material change" << std::endl;

--- a/Engine/Core/src/yougine/managers/ComponentExportParameterManager.h
+++ b/Engine/Core/src/yougine/managers/ComponentExportParameterManager.h
@@ -36,7 +36,7 @@ namespace yougine::managers
          * \return
          */
         template <class fieldType>
-        static std::function<void(std::shared_ptr<assetnamespace::Asset>)> Generate_AssetTypeField_Switch_Function(std::shared_ptr<components::Component> component, std::shared_ptr<fieldType>* field, std::string paramter_name) {
+        static std::function<void(std::shared_ptr<assetnamespace::Asset>)> Generate_AssetTypeField_Switch_Function(components::Component* component, std::shared_ptr<fieldType>* field, std::string paramter_name) {
             std::function<void(std::shared_ptr<assetnamespace::Asset>)> function
                 = [=](std::shared_ptr<assetnamespace::Asset> input)
             {

--- a/Engine/UserEngineCommon/include/UserShare/GameObject.h
+++ b/Engine/UserEngineCommon/include/UserShare/GameObject.h
@@ -20,7 +20,7 @@ namespace yougine
     private:
         GameObject(Scene*, std::string, GameObject*);
         Scene* scene;
-        std::vector<components::Component*> components;
+        std::vector<std::shared_ptr<components::Component>> components;
         std::string name;
         Layer* layer;
         GameObject* gameobject_parent;
@@ -40,17 +40,18 @@ namespace yougine
         std::list<GameObject*> GetChildObjects();
         bool operator==(const GameObject& rhs) const;
         Scene* GetScene();
-
-
+        void Dispose();
+        ~GameObject();
         void AddComponent(components::Component* component);
         void RemoveComponent(components::Component* component);
         template <class T> T* GetComponent()
         {
             T* component;
 
-            for (components::Component* c : components)
+            for (auto& c : components)
             {
-                component = dynamic_cast<T*>(c);
+                auto c_ptr = c.get();
+                component = dynamic_cast<T*>(c_ptr);
                 if (component != nullptr)
                 {
                     return component;

--- a/Engine/UserEngineCommon/include/UserShare/Scene.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/Scene.cpp
@@ -76,6 +76,10 @@ namespace yougine
         for (GameObject* game_object : gameobject_list)
         {
             r_obj = RecursiveGameObjects({ game_object }, name);
+            if (r_obj != nullptr)
+            {
+                break;
+            }
         }
 
         return r_obj;

--- a/Engine/UserEngineCommon/include/UserShare/Scene.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/Scene.cpp
@@ -31,6 +31,24 @@ namespace yougine
         return gameobject;
     }
 
+    void Scene::RemoveGameObjcect(GameObject* remove_target)
+    {
+
+        auto it = std::find(gameobject_list.begin(), gameobject_list.end(), remove_target);
+        if (it != gameobject_list.end()) {
+            std::cout << "Found: " << *it << std::endl;
+            this->gameobject_list.remove_if([&](GameObject* x) {
+                bool to_remove = x->name == remove_target->name;
+
+                return to_remove;
+                });
+            delete remove_target;
+        }
+        else {
+            std::cout << "Not found" << std::endl;
+        }
+    }
+
     //処理変える
     void Scene::RemoveGameObject(GameObject* gameobject)
     {

--- a/Engine/UserEngineCommon/include/UserShare/Scene.h
+++ b/Engine/UserEngineCommon/include/UserShare/Scene.h
@@ -32,6 +32,7 @@ namespace yougine
         std::string GetName();
         void SetName(std::string);
         GameObject* CreateGameObject(std::string, GameObject*);
+        void RemoveGameObjcect(GameObject* remove_target);
         GameObject* GetGameObjectByName(std::string);
         void InitializeAllGameObjcts();
 

--- a/Engine/UserEngineCommon/include/UserShare/components/Component.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/components/Component.cpp
@@ -15,6 +15,8 @@ namespace yougine::components
 
     Component::~Component()
     {
+        std::cout << "~Component  " << (int)this->GetComponentName() << std::endl;
+        UnregisterThisComponentFromComponentList();
     }
 
     //private
@@ -72,8 +74,10 @@ namespace yougine::components
 
     void Component::UnregisterThisComponentFromComponentList()
     {
-        this->register_component_list->RemoveComponentFromDictionary(this->component_name, this);
-        this->register_component_list = nullptr;
+        if (register_component_list != nullptr) {
+            this->register_component_list->RemoveComponentFromDictionary(this->component_name, this);
+            this->register_component_list = nullptr;
+        }
     }
 
     //登録されているかどうか


### PR DESCRIPTION
# 概要
- ヒエラルキーウィンドー上で右クリックすることでコンテキストメニューが表示されるように。
- 選択したオブジェクトを削除できる機能を実装
- シーンからオブジェクトを削除する機能も実装した

![image](https://github.com/heller77/Yougine/assets/60052348/9f309dbf-be59-4de1-ac03-88ade9103cf8)

# 修正
- fix #101 

