### PR TITLE
プロジェクトウィンドーで表示するパスをユーザフォルダに設定、および、アセットをリロードするボタンを実装

### DIFF
--- a/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
@@ -208,6 +208,14 @@ void editor::projectwindows::ProjectWindow::Draw()
     }
     ImGui::SameLine();
     ImGui::Text(path.c_str());
+    ImGui::SameLine();
+
+    if (ImGui::Button("AssetReload"))
+    {
+        projects::Project::GetInstance()->AssetInitialize();
+        CreateView(this->now_display_folderpath);
+    }
+
     ImGui::Separator();
 
     ImVec2 button_size(140, 40);

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
@@ -210,6 +210,7 @@ void editor::projectwindows::ProjectWindow::Draw()
     ImGui::Text(path.c_str());
     ImGui::SameLine();
 
+    //アセットをリロードするボタン。
     if (ImGui::Button("AssetReload"))
     {
         projects::Project::GetInstance()->AssetInitialize();

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
@@ -185,9 +185,26 @@ void editor::projectwindows::ProjectWindow::Draw()
     if (ImGui::Button("up"))
     {
         auto parent = std::filesystem::path(path).parent_path();
-        std::cout << "parent path : " << parent << std::endl;
-        this->now_display_folderpath = parent.string();
-        UpdateNextFrame();
+        //プロジェクトのパスより上だったら上がらない
+        auto projectpath = projects::Project::GetInstance()->GetProjectFolderPath();
+        auto relativePath = parent.lexically_relative(projectpath);
+        bool isupper_fromProjectpath = false;
+        for (const auto& part : relativePath)
+        {
+            if (part == "..") {
+                // ".."が見つかった場合、基準パスより上にある
+                isupper_fromProjectpath = true;
+                break;
+            }
+        }
+
+        if (!isupper_fromProjectpath)
+        {
+            std::cout << "parent path : " << parent << std::endl;
+
+            this->now_display_folderpath = parent.string();
+            UpdateNextFrame();
+        }
     }
     ImGui::SameLine();
     ImGui::Text(path.c_str());

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
@@ -21,7 +21,7 @@ editor::projectwindows::ProjectWindow::ProjectWindow(editor::EditorWindowsManage
     yougine::Scene* scene)
     : EditorWindow(editor_windows_manager, editor::EditorWindowName::ProjectWindow)
 {
-    now_display_folderpath = projects::Project::GetInstance()->GetProjectFolderPath_ByTypeString();
+    now_display_folderpath = projects::Project::GetInstance()->GetUserFolderPath().string();
     auto lastchar = now_display_folderpath[now_display_folderpath.size() - 1];
     if (lastchar == '/') {
         now_display_folderpath.pop_back();
@@ -186,7 +186,7 @@ void editor::projectwindows::ProjectWindow::Draw()
     {
         auto parent = std::filesystem::path(path).parent_path();
         //プロジェクトのパスより上だったら上がらない
-        auto projectpath = projects::Project::GetInstance()->GetProjectFolderPath();
+        auto projectpath = projects::Project::GetInstance()->GetUserFolderPath();
         auto relativePath = parent.lexically_relative(projectpath);
         bool isupper_fromProjectpath = false;
         for (const auto& part : relativePath)


### PR DESCRIPTION
プロジェクトウィンドーで表示するパスをユーザフォルダに設定、および、アセットをリロードするボタンを実装

vscodeなどでアセットに対応した拡張子のファイルを生成したら、リロードするボタンを押せばアセットと認識されるように成る。

![image](https://github.com/heller77/Yougine/assets/60052348/7e83766c-8dc6-40c6-8a47-894023f70f04)
