### PR TITLE
プロジェクトウィンドーからアセットの生成、削除ができるように

### DIFF
--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.cpp
@@ -57,6 +57,11 @@ const std::filesystem::path editor::projectwindows::assets::elements::model::Ass
     return this->path;
 }
 
+const std::filesystem::path editor::projectwindows::assets::elements::model::Asset::GetAssetInfoFilePath()
+{
+    return this->assetinfo_filepath;
+}
+
 void editor::projectwindows::assets::elements::model::Asset::SwapParameter(std::string parameter_name,
     std::shared_ptr<assetparameters::Parameter> parameter)
 {

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Asset.h
@@ -34,6 +34,7 @@ namespace editor::projectwindows::assets::elements::model
         virtual void Export() = 0;
         std::shared_ptr<utility::youginuuid::YougineUuid> GetAssetId();
         const std::filesystem::path GetFilePath();
+        const std::filesystem::path GetAssetInfoFilePath();
         void SwapParameter(std::string parameter_name, std::shared_ptr<assetparameters::Parameter> parameter);
 
         // template <class fieldType>

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.cpp
@@ -221,6 +221,89 @@ void editor::projectwindows::ProjectWindow::Draw()
 
     ImVec2 button_size(140, 40);
 
+
+
+    // ウィンドウ全体での右クリックメニュー
+    if (ImGui::BeginPopupContextWindow("project_context_menu")) {
+
+        if (ImGui::BeginMenu("filegenerate")) {
+            // 「txt」というメニューアイテム
+            if (ImGui::MenuItem("mat")) {
+                // ポップアップを開く
+                show_input_popup = true;
+                this->inputwindow_generatefile_extension = ".mat";
+            }
+            else if (ImGui::MenuItem("input filenname(with extension)"))
+            {
+                // ポップアップを開く
+                show_input_popup = true;
+                this->inputwindow_generatefile_extension = "";
+            }
+
+            // 「create」メニューの終了
+            ImGui::EndMenu();
+        }
+
+        //アセットを選択した状態なら
+        if (SelectionInfo::GetInstance()->GetRecentClickTarget() == SelectTarget::Projectwindow &&
+            SelectionInfo::GetInstance()->GetSelectElementInProjectWindow() != nullptr
+            )
+        {
+            auto selectfile = SelectionInfo::GetInstance()->GetSelectElementInProjectWindow();
+            auto asset = selectfile->GetAsset();
+            if (ImGui::BeginMenu("remove"))
+            {
+                auto removefile_label = "remove " + asset->GetFilePath().filename().string();
+                if (ImGui::MenuItem(removefile_label.c_str())) {
+                    auto filepath = asset->GetFilePath();
+                    auto assetinfofilepath = asset->GetAssetInfoFilePath();
+                    std::filesystem::remove(filepath);
+                    std::filesystem::remove(assetinfofilepath);
+
+                    projects::Project::GetInstance()->AssetInitialize();
+                    CreateView(this->now_display_folderpath);
+                    SelectionInfo::GetInstance()->SetSelctionInfo(nullptr);
+                }
+                ImGui::EndMenu();
+            }
+
+
+        }
+
+
+        ImGui::EndPopup();
+
+    }
+    // ウィンドウの表示制御
+    if (show_input_popup) {
+        ImGui::Begin("file generate", &show_input_popup);
+
+        if (inputwindow_generatefile_extension == "")
+        {
+            // テキスト入力
+            ImGui::InputText("inputfilename", inputwindow_textbuffer, IM_ARRAYSIZE(inputwindow_textbuffer));
+        }
+        else {
+            // テキスト入力
+            ImGui::InputText(inputwindow_generatefile_extension.c_str(), inputwindow_textbuffer, IM_ARRAYSIZE(inputwindow_textbuffer));
+        }
+        // ファイル生成ボタン
+        if (ImGui::Button("generate")) {
+            // テキストに基づいてファイルを生成
+            auto generatefile = now_display_folderpath + "/" + inputwindow_textbuffer + inputwindow_generatefile_extension;
+            std::ofstream file(generatefile);
+            std::cout << generatefile << " generate" << std::endl;
+            projects::Project::GetInstance()->AssetInitialize();
+            CreateView(this->now_display_folderpath);
+
+            // ウィンドウを閉じる
+            show_input_popup = false;
+        }
+
+        ImGui::End();
+    }
+
+
     for (auto element_of_project_view : this->assetvies_vector)
     {
         element_of_project_view->DrawElement();

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.h
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/ProjectWindow.h
@@ -37,6 +37,17 @@ namespace editor::projectwindows
         bool is_updateelements_flag;
 
         // std::shared_ptr<editor::projectwindows::assets::elements::model::Asset> GenerateAssetFromFile(std::filesystem::path path, std::shared_ptr<utility::youginuuid::YougineUuid> uuid);
+
+        /**
+         * \brief ファイルを入力するウィンドをーポップアップさせるためのフラグ
+         */
+        bool show_input_popup;
+        /**
+         * \brief ファイルを入力するウィンドで入力する
+         */
+        char inputwindow_textbuffer[256];
+        //ファイル生成するwindow（inputwindow）で生成されるファイルの拡張子
+        std::string inputwindow_generatefile_extension;
     public:
         void Draw() override;
 

--- a/Engine/Core/src/yougine/Projects/Project.cpp
+++ b/Engine/Core/src/yougine/Projects/Project.cpp
@@ -75,7 +75,15 @@ std::shared_ptr<editor::projectwindows::assets::elements::model::Asset> projects
     }
     else
     {
-        return nullptr;
+        std::ifstream ifs(path.string());
+        if (ifs.fail()) {
+            std::cerr << "Failed to open file. __ in project window" << std::endl;
+            return nullptr;
+        }
+        //アセット生成
+        auto asset = std::make_shared<editor::projectwindows::assets::elements::model::TextAsset>(path, uuid);
+        asset->Export();
+        return asset;
     }
 }
 


### PR DESCRIPTION
# アセット生成機能
プロジェクトウィンドー上で右クリックするとアセットを生成できるように
- filegenerate/mat　でマテリアルを生成できる
- filegenerate/input filename(with extension) で任意の拡張子のアセットを作成できる
 
※ fragなどエンジンが対応している拡張子はmat同様に生成出来ると良さそう
![image](https://github.com/heller77/Yougine/assets/60052348/6247d386-ea9b-402b-b1a5-cc9b55abb35f)

# アセット削除機能
最後に選択したアセットを削除できる機能
![image](https://github.com/heller77/Yougine/assets/60052348/492a0394-b1e2-408c-875b-c53ece0d4fbd)

※アセット以外を選択した状態だと削除メニューは表示されない
![image](https://github.com/heller77/Yougine/assets/60052348/a5d17577-ff0c-417d-9436-8da6b8bb8055)
