### PR TITLE
インスペクターでAddComponentした時にエディタが更新されるようにするのと、エディタからRemoveComponentが出来るように

### DIFF
--- a/Engine/Core/src/yougine/Editor/ComponentViewer.cpp
+++ b/Engine/Core/src/yougine/Editor/ComponentViewer.cpp
@@ -54,4 +54,9 @@ namespace editor
     {
         return component_name;
     }
+
+    yougine::components::Component* ComponentViewer::GetComponent()
+    {
+        return this->component;
+    }
 }

--- a/Engine/Core/src/yougine/Editor/ComponentViewer.h
+++ b/Engine/Core/src/yougine/Editor/ComponentViewer.h
@@ -27,5 +27,6 @@ namespace editor
         ~ComponentViewer();
         void DrawViews();
         std::string GetComponentName();
+        yougine::components::Component* GetComponent();
     };
 }

--- a/Engine/Core/src/yougine/Editor/InspectorWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/InspectorWindow.cpp
@@ -155,6 +155,8 @@ namespace editor
                     selected = i;
                     selection_info->GetInstance()->GetSelectObject()->AddComponent(
                         componentfactory->CreateComponent(componentNames[selected]));
+                    //viewを更新
+                    SelectionInfo::GetInstance()->InitializeComponentViewersOnChangeObject(SelectionInfo::GetInstance()->GetSelectObject());
                 }
             ImGui::EndPopup();
         }

--- a/Engine/Core/src/yougine/Editor/InspectorWindow.cpp
+++ b/Engine/Core/src/yougine/Editor/InspectorWindow.cpp
@@ -127,6 +127,18 @@ namespace editor
             bool c_tree = ImGui::CollapsingHeader(c_viewer->GetComponentName().c_str());
             if (c_tree)
             {
+                //コンポーネントを削除するボタン
+                if (ImGui::Button("remove"))
+                {
+                    auto component = c_viewer->GetComponent();
+                    auto gameobjcet = component->GetGameObject();
+                    gameobjcet->RemoveComponent(component);
+
+                    //viewを更新
+                    SelectionInfo::GetInstance()->InitializeComponentViewersOnChangeObject(SelectionInfo::GetInstance()->GetSelectObject());
+                    break;
+                }
+
                 c_viewer->DrawViews();
             }
         }


### PR DESCRIPTION
以下の様にRemoveボタンを追加。このコンポーネントを削除。
![image](https://github.com/heller77/Yougine/assets/60052348/d7e7cfac-806f-47ee-9202-b9db3cde754a)

以前からあった、AddComponentボタンでコンポーネントを追加してもエディタにすぐ反映されなかった問題も解消。