### PR TITLE
アセット参照の際に拡張子でアセットのフィルターを実装

### DIFF
--- a/Engine/Core/src/yougine/Editor/InspectorWindows/AssetView/Option/AssetViewOption.cpp
+++ b/Engine/Core/src/yougine/Editor/InspectorWindows/AssetView/Option/AssetViewOption.cpp
@@ -8,11 +8,12 @@
 // }
 
 
-editor::inspectorwindows::assetviews::options::AssetViewOption::AssetViewOption(bool is_input_able, bool is_only_display_not_write, bool isAsset)
+editor::inspectorwindows::assetviews::options::AssetViewOption::AssetViewOption(bool is_input_able, bool is_only_display_not_write, bool isAsset, std::filesystem::path assetfile_extension)
 {
     this->is_input_able = is_input_able;
     this->is_only_display_not_write = is_only_display_not_write;
     this->isAsset = isAsset;
+    this->assetfile_extension = assetfile_extension;
 }
 
 void editor::inspectorwindows::assetviews::options::AssetViewOption::SetInputAction(
@@ -51,5 +52,18 @@ bool editor::inspectorwindows::assetviews::options::AssetViewOption::GetOnlyDisp
 bool editor::inspectorwindows::assetviews::options::AssetViewOption::GetIsAsset()
 {
     return this->isAsset;
+}
+
+std::filesystem::path editor::inspectorwindows::assetviews::options::AssetViewOption::GetAssetFileExtension()
+{
+    //アセットであれば返す
+    if (this->isAsset)
+    {
+        return assetfile_extension;
+    }
+    else
+    {
+        return "";
+    }
 }
 

--- a/Engine/Core/src/yougine/Editor/InspectorWindows/AssetView/Option/AssetViewOption.h
+++ b/Engine/Core/src/yougine/Editor/InspectorWindows/AssetView/Option/AssetViewOption.h
@@ -1,4 +1,5 @@
 ﻿#pragma once
+#include <filesystem>
 #include <functional>
 
 #include "UserShare/utilitys/uuid/YougineUuid.h"
@@ -32,9 +33,14 @@ namespace editor::inspectorwindows::assetviews::options
         bool is_only_display_not_write;
 
         bool isAsset;
+
+        /**
+         * \brief アセットのファイルの拡張子
+         */
+        std::filesystem::path assetfile_extension;
         std::function<void(std::shared_ptr<editor::projectwindows::assets::elements::model::Asset>)> setAsset;
     public:
-        AssetViewOption(bool is_input_able = false, bool is_only_display_not_write = false, bool isAsset = false);
+        AssetViewOption(bool is_input_able = false, bool is_only_display_not_write = false, bool isAsset = false, std::filesystem::path assetfile_extension = "");
 
 
         void SetInputAction(std::function<void(std::shared_ptr<editor::projectwindows::assets::elements::model::Asset>)> setAsset);
@@ -45,6 +51,7 @@ namespace editor::inspectorwindows::assetviews::options
 
         bool GetOnlyDisplayNotWrite();
         bool GetIsAsset();
+        std::filesystem::path GetAssetFileExtension();
     };
 
 

--- a/Engine/Core/src/yougine/Editor/InspectorWindows/AssetView/view/AssetView.cpp
+++ b/Engine/Core/src/yougine/Editor/InspectorWindows/AssetView/view/AssetView.cpp
@@ -112,8 +112,7 @@ AssetView::AssetView::AssetView(std::shared_ptr<editor::projectwindows::assets::
             //選んだらvalueなりにセットする
             // option->FireInputAction(utility::youginuuid::YougineUuid("fd"));
             auto yougineuuid = std::any_cast<std::shared_ptr < utility::youginuuid::YougineUuid >> (value);
-
-            this->parameter_vec.emplace_back(std::make_shared<utility::view::parameters::AssetReference>(key.c_str(), yougineuuid, option->GetInputAction_input_Asset()));
+            this->parameter_vec.emplace_back(std::make_shared<utility::view::parameters::AssetReference>(key.c_str(), yougineuuid, "", option->GetInputAction_input_Asset()));
         }
 
         auto template_start_pos = type_name.find("<");

--- a/Engine/Core/src/yougine/Editor/InspectorWindows/AssetView/view/AssetView.cpp
+++ b/Engine/Core/src/yougine/Editor/InspectorWindows/AssetView/view/AssetView.cpp
@@ -112,7 +112,7 @@ AssetView::AssetView::AssetView(std::shared_ptr<editor::projectwindows::assets::
             //選んだらvalueなりにセットする
             // option->FireInputAction(utility::youginuuid::YougineUuid("fd"));
             auto yougineuuid = std::any_cast<std::shared_ptr < utility::youginuuid::YougineUuid >> (value);
-            this->parameter_vec.emplace_back(std::make_shared<utility::view::parameters::AssetReference>(key.c_str(), yougineuuid, "", option->GetInputAction_input_Asset()));
+            this->parameter_vec.emplace_back(std::make_shared<utility::view::parameters::AssetReference>(key.c_str(), yougineuuid, option->GetAssetFileExtension(), option->GetInputAction_input_Asset()));
         }
 
         auto template_start_pos = type_name.find("<");

--- a/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
+++ b/Engine/Core/src/yougine/Editor/ProjectWindows/Assets/element/Model/Material/Material.cpp
@@ -16,7 +16,7 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
     this->parameter[GETVALUENAME(uuid)] = std::make_shared<assetparameters::Parameter>(uuid->convertstring(), onlydisplay_option);
 
     //fragment shader　設定
-    auto fragment_assetoption = std::make_shared<option_type>(false, false, true);
+    auto fragment_assetoption = std::make_shared<option_type>(false, false, true, ".frag");
     // auto fragassetset_function
     //     = this->Generate_Field_SwitchFunction(&frag_asset_uuid, fragment_assetoption,
     //         GETVALUENAME(frag_asset_uuid));
@@ -40,7 +40,7 @@ void editor::projectwindows::assets::elements::model::materials::Material::Initi
     this->parameter[GETVALUENAME(frag_asset)] = std::make_shared<assetparameters::Parameter>(frag_asset->GetAssetId(), fragment_assetoption);
 
     //vertexshader 設定
-    auto vertex_assetoption = std::make_shared<option_type>(false, false, true);
+    auto vertex_assetoption = std::make_shared<option_type>(false, false, true, ".vert");
     auto vert_function
         = this->Generate_Field_SwitchFunction(&vert_asset, vertex_assetoption,
             GETVALUENAME(vert_asset));

--- a/Engine/Core/src/yougine/Editor/PropertiesInputField.cpp
+++ b/Engine/Core/src/yougine/Editor/PropertiesInputField.cpp
@@ -66,8 +66,9 @@ namespace editor
                     ImGui::Text(asset->GetAssetId()->convertstring().c_str());
                     asset->GetParameter();
 
+                    auto assetfile_extension = asset->GetFilePath().extension();
 
-                    std::make_shared<utility::view::parameters::AssetReference>(val_name, asset->GetAssetId(), [&](std::shared_ptr<editor::projectwindows::assets::elements::model::Asset> input)
+                    std::make_shared<utility::view::parameters::AssetReference>(val_name, asset->GetAssetId(), assetfile_extension, [&](std::shared_ptr<editor::projectwindows::assets::elements::model::Asset> input)
                         {
                             func(input);
                         })->Draw();

--- a/Engine/Core/src/yougine/utilitys/view/parameters/AssetReference.cpp
+++ b/Engine/Core/src/yougine/utilitys/view/parameters/AssetReference.cpp
@@ -18,6 +18,14 @@ void utility::view::parameters::AssetReference::Draw()
         {
 
             const bool is_selected = (select_index == n);
+            auto asset = assetdatabase->GetAsset(id_names[n].GetId());
+            std::filesystem::path filename = asset->GetFilePath();
+            auto filename_extension = filename.extension();
+            if (filename.extension() != this->extension && extension != "")
+            {
+                continue;
+            }
+
             //選んだ時
             if (ImGui::Selectable(id_names[n].GetName().c_str(), is_selected)) {
                 std::cout << n << " " << id_names[n].GetId() << std::endl;
@@ -34,9 +42,11 @@ void utility::view::parameters::AssetReference::Draw()
     }
 }
 
-utility::view::parameters::AssetReference::AssetReference(std::string label, std::shared_ptr<utility::youginuuid::YougineUuid> yougine_uuid, std::function<void(std::shared_ptr<editor::projectwindows::assets::elements::model::Asset>)> asset_set_func)
+utility::view::parameters::AssetReference::AssetReference(std::string label, std::shared_ptr<utility::youginuuid::YougineUuid> yougine_uuid, std::filesystem::path extension, std::function<void(std::shared_ptr<editor::projectwindows::assets::elements::model::Asset>)> asset_set_func)
 {
     this->label = label;
+
+    this->extension = extension;
 
     auto assetdatabase = projects::Project::GetInstance()->GetDataBase();
     const auto asset_map = assetdatabase->GetAssetList();

--- a/Engine/Core/src/yougine/utilitys/view/parameters/AssetReference.h
+++ b/Engine/Core/src/yougine/utilitys/view/parameters/AssetReference.h
@@ -5,6 +5,7 @@
 #include "ParameterView.h"
 #include "../../../Editor/ProjectWindows/Assets/element/Model/Asset.h"
 
+#include <filesystem>
 namespace utility::view::parameters
 {
     struct id_name
@@ -31,8 +32,11 @@ namespace utility::view::parameters
         int select_index;
         std::vector<id_name> id_names;
         std::function<void(std::shared_ptr<editor::projectwindows::assets::elements::model::Asset>)> asset_set_func;
+
+        std::filesystem::path extension;
     public:
         void Draw() override;
-        AssetReference(std::string label, std::shared_ptr<utility::youginuuid::YougineUuid> yougine_uuid, std::function<void(std::shared_ptr<editor::projectwindows::assets::elements::model::Asset>)> asset_set_func);
+        AssetReference(std::string label, std::shared_ptr<utility::youginuuid::YougineUuid> yougine_uuid,
+            std::filesystem::path extension, std::function<void(std::shared_ptr<editor::projectwindows::assets::elements::model::Asset>)> asset_set_func);
     };
 }


### PR DESCRIPTION
コンポーネントからアセットを参照する時に、指定したファイル拡張子のみフィルタリングできるように
![image](https://github.com/heller77/Yougine/assets/60052348/a52639c0-e0fa-463b-b933-e71ca5d990fd)


アセットからアセットを参照する時に、指定したファイル拡張子のみフィルタリングできるように
![image](https://github.com/heller77/Yougine/assets/60052348/d35b9868-a639-40b4-955c-2193320ed69d)

