### PR TITLE
プレイボタンを押したら、ユーザスクリプトをコンパイルしてコンポーネントも更新されるように

### DIFF
--- a/Engine/Core/src/yougine/BuildScript/UserScriptCompiler.cpp
+++ b/Engine/Core/src/yougine/BuildScript/UserScriptCompiler.cpp
@@ -9,7 +9,8 @@ void builders::UserScriptCompiler::Compile()
 {
     FreeLibrary(userscriptModule);
     auto dllfolder = builders::UserScriptCompiler::GetDLLPath().parent_path();
-    std::filesystem::remove_all(dllfolder);
+    // todo heller77 : pdbファイル名はどこかの変数で管理削除
+    std::filesystem::remove(dllfolder / "UserScriptProject.pdb");
 
     //cmake D:\Yougin\ -DCMAKE_BUILD_TYPE=Release -G"Visual Studio 16 2019" -B D:\Yougin\a
     //cmake --build D:\Yougin\a  --config Release

--- a/Engine/Core/src/yougine/BuildScript/UserScriptCompiler.cpp
+++ b/Engine/Core/src/yougine/BuildScript/UserScriptCompiler.cpp
@@ -1,9 +1,16 @@
 ﻿#include "UserScriptCompiler.h"
 
+
 #include "../Projects/Project.h"
+
+HMODULE builders::UserScriptCompiler::userscriptModule;
 
 void builders::UserScriptCompiler::Compile()
 {
+    FreeLibrary(userscriptModule);
+    auto dllfolder = builders::UserScriptCompiler::GetDLLPath().parent_path();
+    std::filesystem::remove_all(dllfolder);
+
     //cmake D:\Yougin\ -DCMAKE_BUILD_TYPE=Release -G"Visual Studio 16 2019" -B D:\Yougin\a
     //cmake --build D:\Yougin\a  --config Release
     //の様なコマンドを実行
@@ -14,6 +21,11 @@ void builders::UserScriptCompiler::Compile()
 
     auto cmd = config_cmd + " & " + build_cmd;
     system(cmd.c_str());
+
+    //DLLをロード。
+    auto userscriptpath = builders::UserScriptCompiler::GetDLLPath();
+    userscriptModule = LoadLibrary(userscriptpath.string().c_str());
+
 }
 
 std::filesystem::path builders::UserScriptCompiler::GetDLLPath()
@@ -21,4 +33,9 @@ std::filesystem::path builders::UserScriptCompiler::GetDLLPath()
     auto relativepath = projects::Project::GetNowIsDebugOrRelease() + "/UserScriptProject.dll";
     auto dll_path = projects::Project::GetInstance()->GetUserScriptFolderAbsolutePath() / relativepath;
     return dll_path;
+}
+
+HMODULE builders::UserScriptCompiler::GetModule()
+{
+    return userscriptModule;
 }

--- a/Engine/Core/src/yougine/BuildScript/UserScriptCompiler.h
+++ b/Engine/Core/src/yougine/BuildScript/UserScriptCompiler.h
@@ -1,14 +1,17 @@
 ﻿#pragma once
 #include <filesystem>
 #include <string>
-
+#include "windows.h"
 namespace builders
 {
     class UserScriptCompiler
     {
+    private:
+        static HMODULE userscriptModule;
     public:
         static void Compile();
         static std::filesystem::path GetDLLPath();
+        static HMODULE GetModule();
 
     };
 }

--- a/Engine/Core/src/yougine/Editor/MenuBar.cpp
+++ b/Engine/Core/src/yougine/Editor/MenuBar.cpp
@@ -1,8 +1,11 @@
 ﻿#include "MenuBar.h"
 
+#include <memory>
+
 #include "../BuildScript/Builder.h"
 #include "../BuildScript/UserScriptCompiler.h"
 #include "../Projects/Project.h"
+#include "../SceneFiles/SceneLoader.h"
 
 editor::MenuBar::MenuBar(EditorWindowsManager* editor_windows_manager, yougine::Scene* scene) : EditorWindow(editor_windows_manager, editor::EditorWindowName::MenuBar)
 {
@@ -51,6 +54,10 @@ void editor::MenuBar::Draw()
         {
             play = true;
             builders::UserScriptCompiler::Compile();
+
+            auto scenefilepath = projects::Project::GetInstance()->GetNowSceneFilePath();
+            auto sceneLoader = std::make_shared<yougine::SceneFiles::SceneLoader>(scenefilepath.string());
+            sceneLoader->SceneUpdate(scene);
         }
     }
     ImGui::SameLine();

--- a/Engine/Core/src/yougine/SceneFiles/SceneLoader.cpp
+++ b/Engine/Core/src/yougine/SceneFiles/SceneLoader.cpp
@@ -5,7 +5,7 @@
 
 namespace yougine::SceneFiles
 {
-    void SceneLoader::InitializeScene(Scene* scene)
+    Scene* SceneLoader::InitializeScene(Scene* scene)
     {
         for (nlohmann::basic_json<nlohmann::ordered_map> e : obj_json["Scene"]["Hierarchy"])
         {
@@ -34,27 +34,17 @@ namespace yougine::SceneFiles
 
             }
         }
+        return scene;
     }
 
 
-    void SceneLoader::CreateScene()
+    Scene* SceneLoader::CreateScene()
     {
         std::string scene_name = obj_json["Scene"]["Name"];
         Scene* scene = new Scene(scene_name);
 
-        jb_scene = scene;
-
         InitializeScene(scene);
-    }
-
-    void SceneLoader::UpdateJsonObj(std::string filepath)
-    {
-        std::ifstream reading(filepath, std::ios::in);
-
-        json o_json;
-        reading >> o_json;
-
-        obj_json = o_json;
+        return scene;
     }
 
     void SceneLoader::SetPropertiesToComponent(components::Component* component, nlohmann::basic_json<nlohmann::ordered_map> j_component)
@@ -109,6 +99,13 @@ namespace yougine::SceneFiles
         }
     }
 
+    SceneLoader::SceneLoader(std::string scenefilepath)
+    {
+        std::ifstream reading(scenefilepath, std::ios::in);
 
+        json o_json;
+        reading >> o_json;
 
+        obj_json = o_json;
+    }
 }

--- a/Engine/Core/src/yougine/SceneFiles/SceneLoader.cpp
+++ b/Engine/Core/src/yougine/SceneFiles/SceneLoader.cpp
@@ -47,6 +47,20 @@ namespace yougine::SceneFiles
         return scene;
     }
 
+    //シーンをリセットする（関数名updateよりresetかも）
+    void SceneLoader::SceneUpdate(Scene* scene)
+    {
+        auto gameobjects = scene->GetGameObjects();
+        for (int i = 0; i < gameobjects.size(); i++)
+        {
+            auto gameobjects = scene->GetGameObjects();
+            auto gameobject = gameobjects.back();
+            scene->RemoveGameObjcect(gameobject);
+        }
+
+        InitializeScene(scene);
+    }
+
     void SceneLoader::SetPropertiesToComponent(components::Component* component, nlohmann::basic_json<nlohmann::ordered_map> j_component)
     {
         std::vector<std::vector<std::any>>* accessable_properties_list = component->GetPtrAccessablePropertiesList();

--- a/Engine/Core/src/yougine/SceneFiles/SceneLoader.h
+++ b/Engine/Core/src/yougine/SceneFiles/SceneLoader.h
@@ -15,15 +15,13 @@ namespace yougine::SceneFiles
     private:
         json obj_json;
 
-    public:
-        Scene* jb_scene;
-
     private:
-        void InitializeScene(Scene* scene);
+        Scene* InitializeScene(Scene* scene);
         void SetPropertiesToComponent(components::Component* component, nlohmann::basic_json<nlohmann::ordered_map> j_component);
 
     public:
-        void CreateScene();
-        void UpdateJsonObj(std::string filepath);
+        SceneLoader(std::string scenefilepath);
+        Scene* CreateScene();
+
     };
 }

--- a/Engine/Core/src/yougine/SceneFiles/SceneLoader.h
+++ b/Engine/Core/src/yougine/SceneFiles/SceneLoader.h
@@ -22,6 +22,7 @@ namespace yougine::SceneFiles
     public:
         SceneLoader(std::string scenefilepath);
         Scene* CreateScene();
+        void SceneUpdate(Scene* scene);
 
     };
 }

--- a/Engine/Core/src/yougine/component_factory/ComponentFactory.cpp
+++ b/Engine/Core/src/yougine/component_factory/ComponentFactory.cpp
@@ -35,9 +35,7 @@ yougine::components::Component* yougine::componentfactorys::ComponentFacotory::C
         return new components::camera::CameraComponent();
     }
     //ここにユーザの作ったカスタムコンポーネントのelse if文も動的に入る予定
-    auto userscriptpath = builders::UserScriptCompiler::GetDLLPath();
-    // HMODULE hModule = LoadLibrary(TEXT("D:/Yougin/userscriptBuild/Release/MyNewDLLProject.dll"));
-    HMODULE hModule = LoadLibrary(userscriptpath.string().c_str());
+    HMODULE hModule = builders::UserScriptCompiler::GetModule();
     if (!hModule) {
         std::cerr << "DLLをロードできませんでした。" << std::endl;
         return nullptr;

--- a/Engine/Core/src/yougine/components/Camera/CameraComponent.cpp
+++ b/Engine/Core/src/yougine/components/Camera/CameraComponent.cpp
@@ -1,8 +1,10 @@
 ﻿#include "CameraComponent.h"
-std::shared_ptr<yougine::components::camera::CameraComponent> yougine::components::camera::CameraComponent::main_camera;
+
+yougine::components::camera::CameraComponent* yougine::components::camera::CameraComponent::main_camera;
 yougine::components::camera::CameraComponent::CameraComponent() : Component(components::ComponentName::kNone)
 {
-    CameraComponent::main_camera = std::shared_ptr<CameraComponent>(this);
+    CameraComponent::main_camera = this;
+
 }
 
 yougine::components::TransformComponent* yougine::components::camera::CameraComponent::GetTransform()
@@ -10,7 +12,7 @@ yougine::components::TransformComponent* yougine::components::camera::CameraComp
     return this->GetGameObject()->GetComponent<TransformComponent>();
 }
 
-std::shared_ptr<yougine::components::camera::CameraComponent> yougine::components::camera::CameraComponent::GetMainCamera()
+yougine::components::camera::CameraComponent* yougine::components::camera::CameraComponent::GetMainCamera()
 {
     return main_camera;
 }

--- a/Engine/Core/src/yougine/components/Camera/CameraComponent.h
+++ b/Engine/Core/src/yougine/components/Camera/CameraComponent.h
@@ -9,11 +9,12 @@ namespace yougine::components::camera
     class CameraComponent : public yougine::components::Component
     {
     private:
-        static std::shared_ptr<CameraComponent> main_camera;
+        static CameraComponent* main_camera;
 
     public:
         CameraComponent();
+        ~CameraComponent();
         TransformComponent* GetTransform();
-        static std::shared_ptr<CameraComponent> GetMainCamera();
+        static yougine::components::camera::CameraComponent* GetMainCamera();
     };
 }

--- a/Engine/Core/src/yougine/managers/RenderManager.cpp
+++ b/Engine/Core/src/yougine/managers/RenderManager.cpp
@@ -183,7 +183,7 @@ namespace yougine::managers
      * \brief ゲームオブジェクトを描画する
      * \param render_component 描画対象のレンダーコンポーネント
      */
-    void RenderManager::RenderOneGameObject(components::RenderComponent* render_component, std::shared_ptr<components::camera::CameraComponent> camera)
+    void RenderManager::RenderOneGameObject(components::RenderComponent* render_component, components::camera::CameraComponent* camera)
     {
         geterror("RenderOneGameObject beforegetprogram");
 

--- a/Engine/Core/src/yougine/managers/RenderManager.h
+++ b/Engine/Core/src/yougine/managers/RenderManager.h
@@ -49,7 +49,7 @@ namespace yougine::managers
 
         GLuint depthBuffer;
 
-        void RenderOneGameObject(components::RenderComponent* render_component, std::shared_ptr<components::camera::CameraComponent> camera);
+        void RenderOneGameObject(components::RenderComponent* render_component, components::camera::CameraComponent* camera);
 
         void MeshBufferInit();
 

--- a/Engine/CoreExeBuildProject/src/main.cpp
+++ b/Engine/CoreExeBuildProject/src/main.cpp
@@ -91,7 +91,7 @@ int main()
 
     int gVCBWidth = 300;
     int gVCBHeight = 300;
-    auto sceneloader = yougine::SceneFiles::SceneLoader();
+
 
 
 
@@ -105,10 +105,8 @@ int main()
     if (error == 0)
     {
         //シーンファイルがあれば
-        auto sceneloader = yougine::SceneFiles::SceneLoader();
-        sceneloader.UpdateJsonObj(scenefilepath);
-        sceneloader.CreateScene();
-        scene = sceneloader.jb_scene;
+        auto sceneloader = yougine::SceneFiles::SceneLoader(scenefilepath);
+        scene = sceneloader.CreateScene();
         fclose(fp);
     }
     else

--- a/Engine/UserEngineCommon/include/UserShare/Scene.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/Scene.cpp
@@ -49,21 +49,6 @@ namespace yougine
         }
     }
 
-    //処理変える
-    void Scene::RemoveGameObject(GameObject* gameobject)
-    {
-        std::list<GameObject*> new_list;
-
-        for (GameObject* obj : gameobject_list)
-        {
-            if (gameobject == obj)
-            {
-                new_list.push_back(obj);
-            }
-        }
-
-        gameobject_list = new_list;
-    }
 
     managers::ComponentList* Scene::GetComponentList()
     {

--- a/Engine/UserEngineCommon/include/UserShare/Scene.h
+++ b/Engine/UserEngineCommon/include/UserShare/Scene.h
@@ -22,7 +22,6 @@ namespace yougine
         std::shared_ptr<managers::UserScriptComponentEntryPointManager> user_script_component_entry_point_manager;
         std::shared_ptr<InputManager> input_manager;
     private:
-        void RemoveGameObject(GameObject*);
         GameObject* RecursiveGameObjects(std::list<GameObject*>, std::string);
 
     public:


### PR DESCRIPTION
# 概要
プレイボタンを押したら、ユーザスクリプトをコンパイルして、シーンの再構築を行うように。ユーザスクリプトのコンポーネントが新しいものになる。

# 懸念点
シーンのオブジェクトを全て削除して、コンポーネントをつけなおすという実装になっているので、処理が重くなっている。ユーザスクリプトのコンポーネントのみ差し替えるような処理になると軽量化できそう。

該当issueは作成済み
- #108