### PR TITLE
Transformコンポーネントにスケールを実装。レンダリングにも反映！

### DIFF
--- a/Engine/Core/src/yougine/managers/RenderManager.cpp
+++ b/Engine/Core/src/yougine/managers/RenderManager.cpp
@@ -219,9 +219,12 @@ namespace yougine::managers
         auto position = transform->GetPosition();
         //回転を取得
         auto rotation = transform->GetRotation();
+        //スケールを取得
+        auto scale = transform->GetScale();
+        glm::mat4 ScaleMat = glm::scale(glm::vec3(scale.x, scale.y, scale.z));
 
         //Model行列を定義
-        glm::mat4 Model = glm::translate(glm::vec3(position.x, position.y, position.z)) * rotation->ConvertToGlmMat4();
+        glm::mat4 Model = glm::translate(glm::vec3(position.x, position.y, position.z)) * rotation->ConvertToGlmMat4() * ScaleMat;
         glm::mat4 MVP = Projection * View * Model;
         auto vShader_mvp_pointer = glGetUniformLocation(render_component->GetProgram(), "mvp");
         glUniformMatrix4fv(vShader_mvp_pointer, 1, GL_FALSE, &MVP[0][0]);

--- a/Engine/UserEngineCommon/include/UserShare/components/TransformComponent.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/components/TransformComponent.cpp
@@ -6,9 +6,10 @@ namespace yougine::components
     {
         this->position = new utility::Vector3(x, y, z);
         this->rotation = utility::Quaternion::GenerateQuartanionFromEuler(0, 0, 0);
-
+        this->scale = new utility::Vector3(1, 1, 1);
         accessable_properties_list.push_back(std::vector<std::any>{position, GETVALUENAME(position)});
         accessable_properties_list.push_back(std::vector<std::any>{rotation, GETVALUENAME(rotation)});
+        accessable_properties_list.push_back(std::vector<std::any>{scale, GETVALUENAME(scale)});
     }
 
     /**

--- a/Engine/UserEngineCommon/include/UserShare/components/TransformComponent.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/components/TransformComponent.cpp
@@ -43,4 +43,15 @@ namespace yougine::components
         *this->rotation = quat;
     }
 
+    utility::Vector3 TransformComponent::GetScale()
+    {
+        return *this->scale;
+    }
+
+    void TransformComponent::SetScale(utility::Vector3 scale)
+    {
+        (*this->scale).x = scale.x;
+        (*this->scale).y = scale.y;
+        (*this->scale).z = scale.z;
+    }
 }

--- a/Engine/UserEngineCommon/include/UserShare/components/TransformComponent.h
+++ b/Engine/UserEngineCommon/include/UserShare/components/TransformComponent.h
@@ -10,6 +10,7 @@ namespace yougine::components
     private:
         utility::Vector3* position;
         std::shared_ptr<utility::Quaternion> rotation;
+        utility::Vector3* scale;
     public:
         TransformComponent(float x, float y, float z);
         utility::Vector3 GetPosition();

--- a/Engine/UserEngineCommon/include/UserShare/components/TransformComponent.h
+++ b/Engine/UserEngineCommon/include/UserShare/components/TransformComponent.h
@@ -17,6 +17,8 @@ namespace yougine::components
         void SetPosition(utility::Vector3 position);
         std::shared_ptr<utility::Quaternion> GetRotation();
         void SetRotation(std::shared_ptr<utility::Quaternion> quat);
+        utility::Vector3 GetScale();
+        void SetScale(utility::Vector3 scale);
 
     };
 }


### PR DESCRIPTION
# 内容
- TransformコンポーネントにVector3でscaleを定義
- 3Dレンダリング時にスケールを参照し、描画に反映するように。

以下の写真は、スケールを変えて同じオブジェクトをレンダリングしている様子。
![image](https://github.com/heller77/Yougine/assets/60052348/27196b2a-8698-4ab2-aec5-5ddfa082bad0)
