### PR TITLE
前フレームからの経過時間が取得できるようになりました。

### DIFF
--- a/Engine/CoreExeBuildProject/src/main.cpp
+++ b/Engine/CoreExeBuildProject/src/main.cpp
@@ -31,6 +31,7 @@
 #include "SceneFiles/SceneFileExporter.h"
 #include "SceneFiles/SceneLoader.h"
 #include "UserShare/InputManager.h"
+#include "UserShare/managers/LoopInfoManager.h"
 
 static void glfw_error_callback(int error, const char* description)
 {
@@ -177,11 +178,12 @@ int main()
     managerlist.push_back(rigidbodymanager);
     //GameManagerを生成
     GameManager* game_manager = new GameManager(managerlist);
-
+    yougine::LoopInfoManager* loop_info_manager = new yougine::LoopInfoManager();
     //一フレーム前にPlayだったか
     bool preIsPlay = false;
     while (glfwWindowShouldClose(window) == GL_FALSE)
     {
+        loop_info_manager->Update();
         input_manager->UpdateInput();
         /*
         if (input_manager->IsPushKey(yougine::KeyBind::RightClick))
@@ -198,7 +200,7 @@ int main()
                 scene->InitializeAllGameObjcts();
             }
             game_manager->Update();
-            scene->Update();
+            scene->Update(loop_info_manager);
         }
         preIsPlay = menubar->GetPlay();
 

--- a/Engine/GameBuildProject/src/main.cpp
+++ b/Engine/GameBuildProject/src/main.cpp
@@ -76,10 +76,9 @@ int main()
     int gVCBHeight = 300;
 
     // yougine::Scene* scene = new yougine::Scene("Scene1");
-    auto sceneloader = yougine::SceneFiles::SceneLoader();
-    sceneloader.UpdateJsonObj(project->GetProjectFolderPath_ByTypeString() + "\\build\\scene.json");
-    sceneloader.CreateScene();
-    yougine::Scene* scene = sceneloader.jb_scene;
+    auto scenefile = project->GetProjectFolderPath_ByTypeString() + "\\build\\scene.json";
+    auto sceneloader = yougine::SceneFiles::SceneLoader(scenefile);
+    yougine::Scene* scene = sceneloader.CreateScene();
     // int gVCBHeig3ht = 300;
     // //レンダーコンポーネントをAdd出来るかのコード（後で消す）
     // auto rendercomponent = new yougine::components::RenderComponent();
@@ -117,15 +116,19 @@ int main()
     //render
     auto rendermanager = yougine::managers::RenderManager(1920, 1080, windowframebuffer, scene->GetComponentList());
     scene->InitializeAllGameObjcts();
+
+
+    yougine::LoopInfoManager* loop_info_manager = new yougine::LoopInfoManager();
     while (glfwWindowShouldClose(window) == GL_FALSE)
     {
+        loop_info_manager->Update();
         // input_manager->UpdateInput();
         rendermanager.RenderScene();
         glfwSwapBuffers(window);
         glfwPollEvents();
 
         game_manager->Update();
-        scene->Update();
+        scene->Update(loop_info_manager);
         /*
         if (input_manager->IsPushKey(yougine::KeyBind::RightClick))
         {

--- a/Engine/UserEngineCommon/UserEngineCommon.vcxproj
+++ b/Engine/UserEngineCommon/UserEngineCommon.vcxproj
@@ -27,8 +27,10 @@
     <ClInclude Include="include\UserShare\GameObject.h" />
     <ClInclude Include="include\UserShare\InputManager.h" />
     <ClInclude Include="include\UserShare\Layer.h" />
+    <ClInclude Include="include\UserShare\LoopInfo.h" />
     <ClInclude Include="include\UserShare\MacroDifHeader.h" />
     <ClInclude Include="include\UserShare\managers\ComponentList.h" />
+    <ClInclude Include="include\UserShare\managers\LoopInfoManager.h" />
     <ClInclude Include="include\UserShare\managers\UserScriptComponentEntryPointManager.h" />
     <ClInclude Include="include\UserShare\Scene.h" />
     <ClInclude Include="include\UserShare\utilitys\Quaternion.h" />
@@ -42,7 +44,9 @@
     <ClCompile Include="include\UserShare\components\UserScriptComponent.cpp" />
     <ClCompile Include="include\UserShare\GameObject.cpp" />
     <ClCompile Include="include\UserShare\InputManager.cpp" />
+    <ClCompile Include="include\UserShare\LoopInfo.cpp" />
     <ClCompile Include="include\UserShare\managers\ComponentList.cpp" />
+    <ClCompile Include="include\UserShare\managers\LoopInfoManager.cpp" />
     <ClCompile Include="include\UserShare\managers\UserScriptComponentEntryPointManager.cpp" />
     <ClCompile Include="include\UserShare\Scene.cpp" />
     <ClCompile Include="include\UserShare\utilitys\Quaternion.cpp" />

--- a/Engine/UserEngineCommon/UserEngineCommon.vcxproj.filters
+++ b/Engine/UserEngineCommon/UserEngineCommon.vcxproj.filters
@@ -63,6 +63,12 @@
     <ClInclude Include="include\UserShare\InputManager.h">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
+    <ClInclude Include="include\UserShare\LoopInfo.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="include\UserShare\managers\LoopInfoManager.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="include\UserShare\utilitys\Split.cpp">
@@ -99,6 +105,12 @@
       <Filter>ソース ファイル</Filter>
     </ClCompile>
     <ClCompile Include="include\UserShare\InputManager.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="include\UserShare\LoopInfo.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="include\UserShare\managers\LoopInfoManager.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Engine/UserEngineCommon/include/UserShare/LoopInfo.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/LoopInfo.cpp
@@ -1,0 +1,6 @@
+﻿#include "LoopInfo.h"
+
+float yougine::LoopInfo::GetDeltaTime()
+{
+    return this->delta_time;
+}

--- a/Engine/UserEngineCommon/include/UserShare/LoopInfo.h
+++ b/Engine/UserEngineCommon/include/UserShare/LoopInfo.h
@@ -1,0 +1,22 @@
+﻿#pragma once
+#include "UserShare/MacroDifHeader.h"
+namespace yougine
+{
+    class LoopInfoManager;
+}
+
+namespace yougine
+{
+    class EXPORT LoopInfo
+    {
+        friend yougine::LoopInfoManager;
+    private:
+        float delta_time;
+    public:
+        /**
+         * \brief 1フレーム前からの経過時間を返す(秒)
+         * \return
+         */
+        float GetDeltaTime();
+    };
+}

--- a/Engine/UserEngineCommon/include/UserShare/Scene.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/Scene.cpp
@@ -3,6 +3,8 @@
 #include <memory>
 #include <memory>
 
+#include "managers/LoopInfoManager.h"
+
 namespace yougine
 {
     Scene::Scene(std::string name)
@@ -96,14 +98,20 @@ namespace yougine
         }
     }
 
+    LoopInfo* Scene::GetLoopInfo()
+    {
+        return this->loop_info;
+    }
+
     void Scene::RegisterOnlyUpdate(components::userscriptcomponents::IUpdatable* i_updatable)
     {
         this->user_script_component_entry_point_manager->SetUpdate(i_updatable);
     }
 
 
-    void Scene::Update()
+    void Scene::Update(LoopInfoManager* loop_info_manager)
     {
+        this->loop_info = loop_info_manager->GetLoopInfo();
         this->input_manager->UpdateInput();
 
 

--- a/Engine/UserEngineCommon/include/UserShare/Scene.h
+++ b/Engine/UserEngineCommon/include/UserShare/Scene.h
@@ -5,6 +5,7 @@
 
 #include "InputManager.h"
 #include "components/userscriptcomponents/IUpdatable.h"
+#include "managers/LoopInfoManager.h"
 #include "managers/UserScriptComponentEntryPointManager.h"
 #include "UserShare/Layer.h"
 #include "UserShare/MacroDifHeader.h"
@@ -21,6 +22,7 @@ namespace yougine
         std::string name;
         std::shared_ptr<managers::UserScriptComponentEntryPointManager> user_script_component_entry_point_manager;
         std::shared_ptr<InputManager> input_manager;
+        LoopInfo* loop_info;
     private:
         GameObject* RecursiveGameObjects(std::list<GameObject*>, std::string);
 
@@ -36,13 +38,14 @@ namespace yougine
         void InitializeAllGameObjcts();
 
         std::shared_ptr<InputManager> GetInputManager();
+        LoopInfo* GetLoopInfo();
 
         void RegisterOnlyUpdate(components::userscriptcomponents::IUpdatable* i_updatable);
         /*
          *ユーザが呼ばない!!
          *
          */
-        void Update();
+        void Update(LoopInfoManager* loop_info_manager);
     };
 
     inline std::shared_ptr<InputManager> Scene::GetInputManager()

--- a/Engine/UserEngineCommon/include/UserShare/managers/LoopInfoManager.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/managers/LoopInfoManager.cpp
@@ -18,7 +18,7 @@ void yougine::LoopInfoManager::Update()
 {
     //1フレーム前との時間差分を計算
     auto now = std::chrono::system_clock::now();
-    std::chrono::duration<double> diff = now - pre_time;
+    std::chrono::duration<double> diff = now - preframe_time;
     this->loop_info->delta_time = diff.count();
-    pre_time = now;
+    preframe_time = now;
 }

--- a/Engine/UserEngineCommon/include/UserShare/managers/LoopInfoManager.cpp
+++ b/Engine/UserEngineCommon/include/UserShare/managers/LoopInfoManager.cpp
@@ -1,0 +1,24 @@
+﻿#include "LoopInfoManager.h"
+
+#include <iostream>
+
+yougine::LoopInfoManager::LoopInfoManager()
+{
+    this->loop_info = std::make_unique<LoopInfo>();
+    loop_info->delta_time = 0;
+
+}
+
+yougine::LoopInfo* yougine::LoopInfoManager::GetLoopInfo()
+{
+    return this->loop_info.get();
+}
+
+void yougine::LoopInfoManager::Update()
+{
+    //1フレーム前との時間差分を計算
+    auto now = std::chrono::system_clock::now();
+    std::chrono::duration<double> diff = now - pre_time;
+    this->loop_info->delta_time = diff.count();
+    pre_time = now;
+}

--- a/Engine/UserEngineCommon/include/UserShare/managers/LoopInfoManager.h
+++ b/Engine/UserEngineCommon/include/UserShare/managers/LoopInfoManager.h
@@ -14,7 +14,11 @@ namespace yougine
     {
     private:
         std::unique_ptr<LoopInfo> loop_info;
-        std::chrono::system_clock::time_point pre_time;
+
+        /**
+         * \brief 一フレーム前のタイムスタンプ
+         */
+        std::chrono::system_clock::time_point preframe_time;
     public:
         LoopInfoManager();
         LoopInfo* GetLoopInfo();

--- a/Engine/UserEngineCommon/include/UserShare/managers/LoopInfoManager.h
+++ b/Engine/UserEngineCommon/include/UserShare/managers/LoopInfoManager.h
@@ -1,0 +1,27 @@
+﻿#pragma once
+#include <chrono>
+#include <memory>
+
+#include "UserShare/LoopInfo.h"
+#include "UserShare/MacroDifHeader.h"
+
+namespace yougine
+{
+    /**
+     * \brief ループにまつわる情報を管理
+     */
+    class EXPORT LoopInfoManager
+    {
+    private:
+        std::unique_ptr<LoopInfo> loop_info;
+        std::chrono::system_clock::time_point pre_time;
+    public:
+        LoopInfoManager();
+        LoopInfo* GetLoopInfo();
+
+        /**
+         * \brief 毎フレームloopinfoを更新
+         */
+        void Update();
+    };
+}


### PR DESCRIPTION
- LoopInfoManagerというクラスでループについての情報（現状deltatimeのみ）を管理、更新するように。
- シーンクラスも参照することで、以下の様にユーザスクリプトから参照できるように。
```cpp
//loopinfoを取得(ループにまつわる情報が格納)
auto loopinfo = this->GetGameObject()->GetScene()->GetLoopInfo();

//前フレームからの経過時間取得して、加算
elapsedtime += loopinfo->GetDeltaTime();
```